### PR TITLE
Fix deprecated Qt API for Qt 6 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/backend_scene"]
 	path = src/backend_scene
-	url = https://github.com/catsout/wallpaper-scene-renderer.git
+	url = https://github.com/RainyPixel/wallpaper-scene-renderer.git

--- a/src/MouseGrabber.cpp
+++ b/src/MouseGrabber.cpp
@@ -4,6 +4,7 @@
 #include <QCoreApplication>
 #include <QHoverEvent>
 #include <QMouseEvent>
+#include <QtGlobal>
 
 using namespace wekde;
 
@@ -44,22 +45,40 @@ void MouseGrabber::sendEvent(QObject* target, QEvent* event) {
 
 void MouseGrabber::sendMouseEvent(QMouseEvent* event) {
     if (m_target) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QMouseEvent temp(event->type(),
+                         mapToItem(m_target, event->position()),
+                         event->globalPosition(),
+                         event->button(),
+                         event->buttons(),
+                         event->modifiers());
+#else
         QMouseEvent temp(event->type(),
                          mapToItem(m_target, event->localPos()),
                          event->screenPos(),
                          event->button(),
                          event->buttons(),
                          event->modifiers());
+#endif
         QCoreApplication::sendEvent(m_target, &temp);
     }
 }
 
 void MouseGrabber::sendHoverEvent(QHoverEvent* event) {
     if (m_target) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        auto newPos = mapToItem(m_target, event->position());
+        QHoverEvent temp(event->type(),
+                         newPos,
+                         event->globalPosition(),
+                         mapToItem(m_target, event->oldPosF()),
+                         event->modifiers());
+#else
         QHoverEvent temp(event->type(),
                          mapToItem(m_target, event->posF()),
                          mapToItem(m_target, event->oldPosF()),
                          event->modifiers());
+#endif
         QCoreApplication::sendEvent(m_target, &temp);
     }
 }

--- a/src/TTYSwitchMonitor.hpp
+++ b/src/TTYSwitchMonitor.hpp
@@ -16,7 +16,7 @@ public:
 signals:
     void ttySwitch(bool sleep);
 
-public slots:
+private slots:
     void handlePrepareForSleep(bool sleep);
 
 private:

--- a/src/backend_mpv/MpvBackend.cpp
+++ b/src/backend_mpv/MpvBackend.cpp
@@ -35,6 +35,9 @@
 //#ifdef ENABLE_X11
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 #    include <QX11Info> // IWYU pragma: keep
+#elif (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
+// Qt 6.0-6.4: use platformNativeInterface for X11 (6.0-6.1) and Wayland (6.0-6.4)
+#    include <qpa/qplatformnativeinterface.h>
 #endif
 //#endif
 #endif
@@ -79,21 +82,24 @@ int CreateMpvContex(mpv_handle* mpv, mpv_render_context** mpv_gl) {
 #if defined(__linux__) || defined(__FreeBSD__)
     if (QGuiApplication::platformName().contains("xcb")) {
         params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
         if (auto* x11App = qGuiApp->nativeInterface<QNativeInterface::QX11Application>()) {
             params[2].data = x11App->display();
         }
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        auto* native   = QGuiApplication::platformNativeInterface();
+        params[2].data = native->nativeResourceForWindow("display", nullptr);
 #else
         params[2].data = QX11Info::display();
 #endif
     }
     if (QGuiApplication::platformName().contains("wayland")) {
         params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
-    #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-            if (auto* waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>()) {
-                params[2].data = waylandApp->display();
-            }
-    #else
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+        if (auto* waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>()) {
+            params[2].data = waylandApp->display();
+        }
+#else
         auto* native   = QGuiApplication::platformNativeInterface();
         params[2].data = native->nativeResourceForWindow("display", nullptr);
 #endif

--- a/src/backend_mpv/qthelper.hpp
+++ b/src/backend_mpv/qthelper.hpp
@@ -114,7 +114,11 @@ private:
         // "QVariant::Type(obsolete), the return value should be interpreted
         // as QMetaType::Type."
         // So a cast really seems to be needed to avoid warnings (urgh).
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        return v.typeId() == static_cast<int>(t);
+#else
         return static_cast<int>(v.type()) == static_cast<int>(t);
+#endif
     }
     void set(mpv_node *dst, const QVariant &src) {
         if (test_type(src, QMetaType::QString)) {

--- a/src/backend_mpv/standalone_viewer/CMakeLists.txt
+++ b/src/backend_mpv/standalone_viewer/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-set(CMAKE_CXX_STANDARD 14) 
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON) 
 project(mpvbackend-viewer)
 

--- a/src/backend_mpv/standalone_viewer/qmlviewer.cpp
+++ b/src/backend_mpv/standalone_viewer/qmlviewer.cpp
@@ -13,7 +13,9 @@ int main(int argc, char **argv)
 		std::cerr << "usage: "+ std::string(argv[0]) +" <video file>\n";
 		return 1;
 	}
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+#endif
     QGuiApplication app(argc, argv);
 	qmlRegisterType<mpv::MpvObject>("mpvtest", 1, 0, "MpvObject");
 	setlocale(LC_NUMERIC, "C");


### PR DESCRIPTION
- MouseGrabber: Use Qt 6 position()/globalPosition()/oldPosition() methods with fallback to Qt 5 localPos()/screenPos()/posF()/oldPosF()
- TTYSwitchMonitor: Make D-Bus slot private (best practice)
- qmlviewer: Guard deprecated AA_DisableHighDpiScaling for Qt 5 only
- CMake: Update standalone_viewer C++ standard from 14 to 17