### PR TITLE
rpm: update spec for RainyPixel fork (Plasma 6/Qt6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             cmake \
             ninja \
             extra-cmake-modules \
-            plasma-framework \
+            libplasma \
             qt6-declarative \
             qt6-websockets \
             qt6-webchannel \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Checkout submodules
-        run: git submodule update --init --force --recursive
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git submodule update --init --force --recursive
 
       - name: Install build dependencies
         run: |
@@ -61,7 +63,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Checkout submodules
-        run: git submodule update --init --force --recursive
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git submodule update --init --force --recursive
 
       - name: Enable RPM Fusion (needed for mpv)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,98 @@
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  # ── Arch Linux (primary target distribution) ──────────────────────────────
+  build-arch:
+    name: Full build — Arch Linux
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    steps:
+      - name: Install git (needed for checkout action inside container)
+        run: pacman -Sy --noconfirm git
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          pacman -Su --noconfirm
+          pacman -S --noconfirm \
+            base-devel \
+            cmake \
+            ninja \
+            extra-cmake-modules \
+            plasma-framework \
+            qt6-declarative \
+            qt6-websockets \
+            qt6-webchannel \
+            vulkan-headers \
+            mpv \
+            lz4
+
+      - name: Configure
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+  # ── Fedora (secondary target distribution) ───────────────────────────────
+  build-fedora:
+    name: Full build — Fedora
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+
+    steps:
+      - name: Install git
+        run: dnf install -y git
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Enable RPM Fusion (needed for mpv)
+        run: |
+          dnf install -y \
+            "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+            "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm"
+          dnf swap -y ffmpeg-free ffmpeg --allowerasing
+          dnf install -y ffmpeg-devel --allowerasing
+
+      - name: Install build dependencies
+        run: |
+          dnf install -y \
+            cmake \
+            ninja-build \
+            extra-cmake-modules \
+            vulkan-headers \
+            plasma-workspace-devel \
+            kf6-plasma-devel \
+            kf6-kcoreaddons-devel \
+            kf6-kpackage-devel \
+            lz4-devel \
+            mpv-libs-devel \
+            qt6-qtbase-private-devel \
+            libplasma-devel \
+            qt6-qtwebchannel-devel \
+            qt6-qtwebsockets-devel \
+            qt6-qtdeclarative-devel
+
+      - name: Configure
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build build -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,9 @@ jobs:
         run: pacman -Sy --noconfirm git
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+
+      - name: Checkout submodules
+        run: git submodule update --init --force --recursive
 
       - name: Install build dependencies
         run: |
@@ -58,8 +59,9 @@ jobs:
         run: dnf install -y git
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+
+      - name: Checkout submodules
+        run: git submodule update --init --force --recursive
 
       - name: Enable RPM Fusion (needed for mpv)
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  clang-format:
+    name: clang-format check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check C++ formatting
+        # --dry-run prints differences; --Werror turns any difference into a
+        # non-zero exit code so the job fails on style violations.
+        run: |
+          find src -name "*.cpp" -o -name "*.hpp" | \
+            xargs clang-format --dry-run --Werror

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  unit-tests:
+    name: FileHelper unit tests (Qt6 only)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        # No submodules needed — tests only depend on Qt6 Core + Test
+
+      - name: Install Qt6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qt6-base-dev cmake ninja-build
+
+      - name: Configure (standalone test build)
+        # Build the tests/ directory directly — avoids the KDE/Plasma/mpv/Vulkan
+        # dependencies that the full plugin requires.
+        run: |
+          cmake -B build/tests -S tests \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build build/tests
+
+      - name: Run tests
+        run: ctest --test-dir build/tests --output-on-failure -V

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/backend_scene"]
 	path = src/backend_scene
-	url = https://github.com/RainyPixel/wallpaper-scene-renderer.git
+	url = https://github.com/CaptSilver/wallpaper-scene-renderer.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,83 +2,83 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Обзор проекта
+## Project Overview
 
-Wallpaper Engine KDE Plugin — плагин для KDE Plasma 6, интегрирующий обои из Wallpaper Engine (Steam) в рабочий стол Linux. Поддерживает Scene (2D), Web и Video обои.
+Wallpaper Engine KDE Plugin — a plugin for KDE Plasma 6 that integrates Wallpaper Engine (Steam) wallpapers into the Linux desktop. Supports Scene (2D), Web, and Video wallpapers.
 
-## Сборка
+## Build
 
 ```bash
-# Инициализация субмодулей (обязательно)
+# Initialize submodules (required)
 git submodule update --init --force --recursive
 
-# Сборка
+# Build
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 
-# Установка
+# Install
 sudo cmake --install build
 
-# Перезапуск plasmashell
+# Restart plasmashell
 systemctl --user restart plasma-plasmashell.service
 ```
 
-### Standalone viewer для отладки
+### Standalone viewer for debugging
 
 ```bash
-# В директории src/backend_scene/standalone_view/
+# In the src/backend_scene/standalone_view/ directory
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 
-# Запуск с Vulkan validation layers
+# Run with Vulkan validation layers
 ./sceneviewer --valid-layer <steamapps>/common/wallpaper_engine/assets <steamapps>/workshop/content/431960/<id>/scene.pkg
 ```
 
-## Архитектура
+## Architecture
 
-### Основные компоненты
+### Main components
 
-- **src/** — C++ код QML-плагина
-  - `plugin.cpp` — точка входа QML-плагина
-  - `FileHelper.cpp` — нативный C++ хелпер для файловых операций (замена Python)
-  - `MouseGrabber` — перехват событий мыши
-  - `TTYSwitchMonitor` — мониторинг переключения TTY через D-Bus
+- **src/** — C++ code for the QML plugin
+  - `plugin.cpp` — QML plugin entry point
+  - `FileHelper.cpp` — native C++ helper for file operations (replaces Python)
+  - `MouseGrabber` — mouse event capture
+  - `TTYSwitchMonitor` — TTY switch monitoring via D-Bus
 
-- **src/backend_mpv/** — MPV бэкенд для видео-обоев
-  - Использует libmpv для воспроизведения
-  - Статическая библиотека `mpvbackend`
+- **src/backend_mpv/** — MPV backend for video wallpapers
+  - Uses libmpv for playback
+  - Static library `mpvbackend`
 
-- **src/backend_scene/** — Vulkan рендерер для Scene обоев
-  - `wescene-renderer` — основная библиотека рендеринга
-  - `wescene-renderer-qml` — Qt/QML обвязка
-  - Требует Vulkan 1.1+
+- **src/backend_scene/** — Vulkan renderer for Scene wallpapers
+  - `wescene-renderer` — main rendering library
+  - `wescene-renderer-qml` — Qt/QML wrapper
+  - Requires Vulkan 1.1+
 
-### Подсистемы backend_scene
+### backend_scene subsystems
 
-- **VulkanRender/** — Vulkan рендеринг и управление ресурсами
-- **RenderGraph/** — автоматические зависимости между проходами
-- **Scene/** — парсинг и представление сцен
-- **Particle/** — система частиц
-- **Audio/** — аудио через miniaudio
-- **Vulkan/** — базовая Vulkan абстракция
-- **WP*Parser.cpp** — парсеры форматов Wallpaper Engine (JSON, MDL, шейдеры, текстуры)
+- **VulkanRender/** — Vulkan rendering and resource management
+- **RenderGraph/** — automatic pass dependency resolution
+- **Scene/** — scene parsing and representation
+- **Particle/** — particle system
+- **Audio/** — audio via miniaudio
+- **Vulkan/** — base Vulkan abstraction
+- **WP*Parser.cpp** — Wallpaper Engine format parsers (JSON, MDL, shaders, textures)
 
 ### QML UI
 
-- **plugin/contents/ui/** — QML интерфейс настроек
-  - `main.qml` — главное окно плагина
-  - `config.qml` — страница конфигурации
-  - `WallpaperListModel.qml` — модель списка обоев
+- **plugin/contents/ui/** — QML settings interface
+  - `main.qml` — main plugin window
+  - `config.qml` — configuration page
+  - `WallpaperListModel.qml` — wallpaper list model
 
-### Сторонние библиотеки (в src/backend_scene/third_party/)
+### Third-party libraries (in src/backend_scene/third_party/)
 
-- Eigen — линейная алгебра
-- glslang — компиляция GLSL в SPIR-V
-- SPIRV-Reflect — рефлексия SPIR-V шейдеров
-- nlohmann/json — парсинг JSON
-- miniaudio — кроссплатформенное аудио
+- Eigen — linear algebra
+- glslang — GLSL to SPIR-V compilation
+- SPIRV-Reflect — SPIR-V shader reflection
+- nlohmann/json — JSON parsing
+- miniaudio — cross-platform audio
 
-## Зависимости
+## Dependencies
 
 ### Arch Linux
 ```bash
@@ -88,24 +88,33 @@ base-devel mpv qt6-declarative qt6-websockets qt6-webchannel vulkan-headers cmak
 
 ### Fedora
 ```bash
-sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel gstreamer1-libav \
-lz4-devel mpv-libs-devel qt6-qtbase-private-devel libplasma-devel \
-qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake extra-cmake-modules
+# Add RPM Fusion repos (required for ffmpeg/mpv)
+sudo dnf install -y \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+
+sudo dnf swap -y ffmpeg-free ffmpeg --allowerasing
+sudo dnf install -y ffmpeg-devel --allowerasing
+
+sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel \
+    kf6-kcoreaddons-devel kf6-kpackage-devel gstreamer1-libav \
+    lz4-devel mpv-libs-devel qt6-qtbase-private-devel libplasma-devel \
+    qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake extra-cmake-modules
 ```
 
-## Отладка
+## Debugging
 
-Логи plasmashell:
+plasmashell logs:
 ```bash
 journalctl /usr/bin/plasmashell -f
-# или
+# or
 plasmashell --replace
 ```
 
-Установить `vulkan-validation-layers` для отладки Vulkan.
+Install `vulkan-validation-layers` for Vulkan debugging.
 
-## Стиль кода
+## Code Style
 
 - C++20
-- Форматирование: `.clang-format` (4 пробела, 100 символов в строке)
+- Formatting: `.clang-format` (4 spaces, 100 character line width)
 - Qt6 / KF6 / Plasma 6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ cmake --build build
 
 ### Arch Linux
 ```bash
-sudo pacman -S extra-cmake-modules plasma-framework gst-libav ninja \
+sudo pacman -S extra-cmake-modules libplasma gst-libav ninja \
 base-devel mpv qt6-declarative qt6-websockets qt6-webchannel vulkan-headers cmake lz4
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,3 +73,9 @@ set(QMLPLUGIN_URI "com.github.catsout.wallpaperEngineKde")
 string(REPLACE "." "/" QMLPLUGIN_INSTALL_URI ${QMLPLUGIN_URI})
 
 add_subdirectory(src)
+
+option(BUILD_TESTS "Build unit tests (requires only Qt6 Core+Test)" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ yay -S wallpaper-engine-kde-plugin-git
 paru -S wallpaper-engine-kde-plugin-git
 ```
 
+### Fedora / rpm-ostree / Bazzite (RPM)
+
+Download the latest RPM from [Releases](https://github.com/CaptSilver/wallpaper-engine-kde-plugin/releases):
+
+```sh
+curl -LO https://github.com/CaptSilver/wallpaper-engine-kde-plugin/releases/download/v1.0/wallpaper-engine-kde-plugin-qt6-0-1.fc43.x86_64.rpm
+```
+
+Install:
+```sh
+# Standard Fedora
+sudo dnf install ./wallpaper-engine-kde-plugin-qt6-0-1.fc43.x86_64.rpm
+
+# rpm-ostree / Bazzite
+rpm-ostree install ./wallpaper-engine-kde-plugin-qt6-0-1.fc43.x86_64.rpm
+```
+
 ### Build from source
 
 #### Dependencies
@@ -95,12 +112,24 @@ rpmbuild --define="commit $(git rev-parse HEAD)" \
     -ba ./rpm/wek.spec
 
 sudo umount ~/rpmbuild/BUILD
-
 # Install (rpm-ostree example)
 rpm-ostree install ~/rpmbuild/RPMS/x86_64/wallpaper-engine-kde-plugin-qt6-*.rpm
 ```
 
-#### Uninstall
+## Activate in Plasma
+
+After installing via any method:
+
+1. Right-click the desktop → **Configure Desktop and Wallpaper...**
+2. Open the **Wallpaper Type** dropdown and select **Wallpaper Engine for KDE**
+3. Under **Steam Library**, point to the folder containing your `steamapps` directory
+   - Usually `~/.local/share/Steam`
+   - *Wallpaper Engine* must be installed in this library
+4. Your subscribed Workshop wallpapers will appear in the list — select one and click **Apply**
+
+> **Note:** After an rpm-ostree/Bazzite install you may need to reboot before the plugin starts working. For cmake installs, restarting plasmashell is enough: `systemctl --user restart plasma-plasmashell.service`
+
+### Uninstall
 1. Remove files listed in `build/install_manifest.txt`
 2. `kpackagetool6 -t Plasma/Wallpaper -r com.github.catsout.wallpaperEngineKde`
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,25 @@ base-devel mpv qt6-declarative qt6-websockets qt6-webchannel vulkan-headers cmak
 
 Fedora:
 ```sh
-# Please add "RPM Fusion" repo first
-sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel gstreamer1-libav \
-lz4-devel mpv-libs-devel qt6-qtbase-private-devel libplasma-devel \
-qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake extra-cmake-modules
+# Add RPM Fusion repos (required for ffmpeg/mpv)
+sudo dnf install -y \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+
+# Replace ffmpeg-free with full ffmpeg
+sudo dnf swap -y ffmpeg-free ffmpeg --allowerasing
+sudo dnf install -y ffmpeg-devel --allowerasing
+
+sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel \
+    kf6-kcoreaddons-devel kf6-kpackage-devel gstreamer1-libav \
+    lz4-devel mpv-libs-devel qt6-qtbase-private-devel libplasma-devel \
+    qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake extra-cmake-modules
 ```
 
 #### Build and Install
 ```sh
 # Download source
-git clone https://github.com/SpeedySH/wallpaper-engine-kde-plugin.git
+git clone https://github.com/captsilver/wallpaper-engine-kde-plugin.git
 cd wallpaper-engine-kde-plugin
 
 # Download submodules
@@ -55,6 +64,40 @@ sudo cmake --install build
 
 # Restart plasmashell
 systemctl --user restart plasma-plasmashell.service
+```
+
+#### Build RPM package (Fedora)
+
+Useful for rpm-ostree/Bazzite systems where layered packages survive updates.
+
+```sh
+git clone https://github.com/captsilver/wallpaper-engine-kde-plugin.git
+cd wallpaper-engine-kde-plugin
+
+# Install build dependencies from spec
+sudo dnf builddep ./rpm/wek.spec
+
+# Initialise submodules
+git submodule update --init --force --recursive
+
+# Copy QML plugin files (required at runtime)
+mkdir -p ~/.local/share/plasma/wallpapers/com.github.catsout.wallpaperEngineKde/
+cp -R ./plugin/* ~/.local/share/plasma/wallpapers/com.github.catsout.wallpaperEngineKde/
+
+# Use tmpfs for the build directory to avoid slow disk writes
+sudo mount -t tmpfs tmpfs ~/rpmbuild/BUILD
+
+# Build the RPM
+rpmbuild --define="commit $(git rev-parse HEAD)" \
+    --define="reporoot $(pwd)" \
+    --define="glslang_ver 11.8.0" \
+    --undefine=_disable_source_fetch \
+    -ba ./rpm/wek.spec
+
+sudo umount ~/rpmbuild/BUILD
+
+# Install (rpm-ostree example)
+rpm-ostree install ~/rpmbuild/RPMS/x86_64/wallpaper-engine-kde-plugin-qt6-*.rpm
 ```
 
 #### Uninstall
@@ -95,6 +138,7 @@ Basic web APIs supported. WebGL may not work properly.
 - **MPV** — requires plugin lib compilation
 
 ## Acknowledgments
+- RainyPixel fork: [RainyPixel/wallpaper-engine-kde-plugin](https://github.com/rainypixel/wallpaper-engine-kde-plugin)
 - Original project: [catsout/wallpaper-engine-kde-plugin](https://github.com/catsout/wallpaper-engine-kde-plugin)
 - [RePKG](https://github.com/notscuffed/repkg)
 - All open-source libraries used in this project

--- a/plugin/contents/ui/Common.qml
+++ b/plugin/contents/ui/Common.qml
@@ -293,7 +293,7 @@ QtObject {
     }
 
     function checklib_websockets(parentItem) {
-        return checklib('QtWebSockets 1.0', parentItem)
+        return checklib('QtWebSockets', parentItem)
     }
 
     function checklib_webchannel(parentItem) {

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,31 +1,55 @@
-### This is for rpm-ostree based system
+## Building an RPM (Fedora / rpm-ostree / Bazzite)
 
+Building an RPM is the recommended approach for immutable systems (Bazzite, Silverblue, etc.)
+where layered packages survive OS updates.
+
+### Prerequisites: RPM Fusion + ffmpeg
+
+```sh
+sudo dnf install -y \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+
+sudo dnf swap -y ffmpeg-free ffmpeg --allowerasing
+sudo dnf install -y ffmpeg-devel --allowerasing
 ```
-# Create and enter toolbox
-toolbox create && toolbox enter
 
-# Add build dependencies
-sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel gstreamer1-libav \
-lz4-devel mpv-libs-devel python3-websockets qt6-qtbase-private-devel libplasma-devel \
-qt5-qtx11extras-devel qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake ninja rpmbuild extra-cmake-modules
+### Build steps
 
-# Clone repo
-git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git
+```sh
+git clone https://github.com/captsilver/wallpaper-engine-kde-plugin.git
 cd wallpaper-engine-kde-plugin
 
-# Install plugin package 
+# Install all build dependencies declared in the spec
+sudo dnf builddep ./rpm/wek.spec
+
+# Initialise submodules
+git submodule update --init --force --recursive
+
+# Copy QML plugin files (required at runtime)
 mkdir -p ~/.local/share/plasma/wallpapers/com.github.catsout.wallpaperEngineKde/
 cp -R ./plugin/* ~/.local/share/plasma/wallpapers/com.github.catsout.wallpaperEngineKde/
 
-mkdir -p ~/rpmbuild/SOURCES
+# Use tmpfs to speed up the build and avoid wearing disk
+sudo mount -t tmpfs tmpfs ~/rpmbuild/BUILD
 
-# Rpmbuild in toolbox
 rpmbuild --define="commit $(git rev-parse HEAD)" \
+    --define="reporoot $(pwd)" \
     --define="glslang_ver 11.8.0" \
     --undefine=_disable_source_fetch \
     -ba ./rpm/wek.spec
 
-# Install package
-cd ~/rpmbuild/RPMS/x86_64
-rpm-ostree install --uninstall=wallpaper-engine-kde-plugin ./<select-rpm-to-install>.rpm
+sudo umount ~/rpmbuild/BUILD
+```
+
+### Install
+
+Standard Fedora:
+```sh
+sudo dnf install ~/rpmbuild/RPMS/x86_64/wallpaper-engine-kde-plugin-qt6-*.rpm
+```
+
+rpm-ostree / Bazzite:
+```sh
+rpm-ostree install ~/rpmbuild/RPMS/x86_64/wallpaper-engine-kde-plugin-qt6-*.rpm
 ```

--- a/rpm/wek.spec
+++ b/rpm/wek.spec
@@ -1,47 +1,64 @@
-Name: wallpaper-engine-kde-plugin-qt6
-
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
-Version: %{shortcommit}
+Name:    wallpaper-engine-kde-plugin-qt6
+Version: 0
 Release: 1%{?dist}
-Summary: A kde wallpaper plugin integrating wallpaper engine
+Summary: A KDE wallpaper plugin integrating Wallpaper Engine (Plasma 6)
 
-Group: Development/System 
-License: GPLv2
-URL: https://github.com/catsout/wallpaper-engine-kde-plugin
-Source0: https://github.com/catsout/wallpaper-engine-kde-plugin/archive/%{commit}.tar.gz
-Source1: https://github.com/KhronosGroup/glslang/archive/refs/tags/%{glslang_ver}.tar.gz
+License: GPL-2.0-only
+URL:     https://github.com/RainyPixel/wallpaper-engine-kde-plugin
 
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildRequires: mpv-libs-devel vulkan-headers plasma-workspace-devel kf6-plasma-devel lz4-devel qt6-qtbase-private-devel qt5-qtx11extras-devel
-Requires: plasma-workspace gstreamer1-libav mpv-libs lz4 python3-websockets qt6-qtwebchannel-devel qt6-qtwebsockets-devel
+# Built from a live git checkout.
 
-%description
+BuildRequires: cmake extra-cmake-modules
+BuildRequires: vulkan-headers
+BuildRequires: plasma-workspace-devel libplasma-devel
+BuildRequires: kf6-plasma-devel
+BuildRequires: kf6-kcoreaddons-devel
+BuildRequires: kf6-kpackage-devel
+BuildRequires: lz4-devel
+BuildRequires: mpv-libs-devel
+BuildRequires: qt6-qtbase-private-devel
+BuildRequires: qt6-qtwebchannel-devel qt6-qtwebsockets-devel
 
-%prep
-%setup -q -n wallpaper-engine-kde-plugin-%{commit}
-%setup -T -D -a 1 -n wallpaper-engine-kde-plugin-%{commit}
-rm -r src/backend_scene
-git clone --recurse-submodules https://github.com/catsout/wallpaper-scene-renderer.git src/backend_scene
+Requires: plasma-workspace
+Requires: gstreamer1-libav
+Requires: mpv-libs
+Requires: lz4
+Requires: qt6-qtwebchannel
+Requires: qt6-qtwebsockets
 
 %global _enable_debug_package 0
 %global debug_package %{nil}
 
+%{?commit:%global shortcommit %(c=%{commit}; echo ${c:0:7})}
+%{!?commit:%global shortcommit unknown}
+
+%description
+A wallpaper plugin integrating Wallpaper Engine into KDE Plasma 6 wallpaper
+settings. This is the RainyPixel fork with native C++ file operations
+(no Python dependency), fixed KDE 6.5+ theme reactivity, and Plasma 6 / Qt6
+support.
+
+%prep
+# No-op: building directly from the git checkout at %{reporoot}
+# Ensure submodules are initialised before calling wallpaper.sh:
+#   git submodule update --init --force --recursive
+
 %build
-mkdir -p build && cd build
-cmake .. -DUSE_PLASMAPKG=ON
-%make_build
+cmake -B %{_builddir}/wek-build \
+      -S %{reporoot} \
+      -DCMAKE_BUILD_TYPE=Release
+cmake --build %{_builddir}/wek-build -- %{?_smp_mflags}
 
 %install
-rm -rf $RPM_BUILD_ROOT
-cd build
-make install DESTDIR=$RPM_BUILD_ROOT
-
-%clean
-rm -rf $RPM_BUILD_ROOT
+DESTDIR=%{buildroot} cmake --install %{_builddir}/wek-build \
+      --prefix %{_prefix}
 
 %files
-%defattr(-,root,root,-)
 %{_libdir}/*
+%{_datadir}/*
 
-%changelog 
+%changelog
+* Sat Feb 28 2026 packager - 0-1
+- Add kf6-kcoreaddons-devel and kf6-kpackage-devel to BuildRequires
+- Port to RainyPixel fork: drop python3-websockets and Qt5 dep,
+  update URL, modernise cmake, remove tarball/setup dependency

--- a/rpm/wek.spec
+++ b/rpm/wek.spec
@@ -4,7 +4,7 @@ Release: 1%{?dist}
 Summary: A KDE wallpaper plugin integrating Wallpaper Engine (Plasma 6)
 
 License: GPL-2.0-only
-URL:     https://github.com/RainyPixel/wallpaper-engine-kde-plugin
+URL:     https://github.com/captsilver/wallpaper-engine-kde-plugin
 
 # Built from a live git checkout.
 

--- a/src/FileHelper.cpp
+++ b/src/FileHelper.cpp
@@ -8,12 +8,13 @@
 #include <QStandardPaths>
 #include <QDateTime>
 
-namespace wekde {
+namespace wekde
+{
 
-FileHelper::FileHelper(QObject* parent) : QObject(parent) {
+FileHelper::FileHelper(QObject* parent): QObject(parent) {
     // Ensure config directory exists
     QDir dir(wallpaperConfigDir());
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         dir.mkpath(".");
     }
 }
@@ -25,9 +26,7 @@ QString FileHelper::configDir() const {
     return xdgConfig + "/wekde";
 }
 
-QString FileHelper::wallpaperConfigDir() const {
-    return configDir() + "/wallpaper";
-}
+QString FileHelper::wallpaperConfigDir() const { return configDir() + "/wallpaper"; }
 
 QString FileHelper::wallpaperConfigFile(const QString& id) const {
     return wallpaperConfigDir() + "/" + id + ".json";
@@ -35,7 +34,7 @@ QString FileHelper::wallpaperConfigFile(const QString& id) const {
 
 QByteArray FileHelper::readFile(const QString& path) {
     QFile file(path);
-    if (!file.open(QIODevice::ReadOnly)) {
+    if (! file.open(QIODevice::ReadOnly)) {
         qWarning() << "FileHelper: Cannot open file:" << path;
         return QByteArray();
     }
@@ -44,9 +43,9 @@ QByteArray FileHelper::readFile(const QString& path) {
 
 qint64 FileHelper::getDirSize(const QString& path, int depth) {
     qint64 totalSize = 0;
-    QDir dir(path);
+    QDir   dir(path);
 
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         return 0;
     }
 
@@ -76,11 +75,12 @@ qint64 FileHelper::getDirSize(const QString& path, int depth) {
         }
 
         // Simpler approach: just iterate with depth limit
-        std::function<qint64(const QString&, int)> calcSize = [&](const QString& dirPath, int currentDepth) -> qint64 {
+        std::function<qint64(const QString&, int)> calcSize = [&](const QString& dirPath,
+                                                                  int currentDepth) -> qint64 {
             if (currentDepth > depth) return 0;
 
             qint64 size = 0;
-            QDir d(dirPath);
+            QDir   d(dirPath);
 
             for (const QFileInfo& info : d.entryInfoList(QDir::Files | QDir::NoDotAndDotDot)) {
                 size += info.size();
@@ -104,37 +104,37 @@ qint64 FileHelper::getDirSize(const QString& path, int depth) {
 QVariantMap FileHelper::getFolderList(const QString& path, const QVariantMap& opt) {
     QVariantMap result;
 
-    bool onlyDir = opt.value("only_dir", true).toBool();
+    bool        onlyDir   = opt.value("only_dir", true).toBool();
     QStringList fallbacks = opt.value("fallbacks", QStringList()).toStringList();
 
     // Find first existing directory
     QString folder = path;
-    QDir dir(folder);
+    QDir    dir(folder);
 
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         for (const QString& fb : fallbacks) {
             QDir fbDir(fb);
             if (fbDir.exists()) {
                 folder = fb;
-                dir = fbDir;
+                dir    = fbDir;
                 break;
             }
         }
     }
 
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         return QVariantMap(); // Return null/empty
     }
 
     result["folder"] = folder;
 
-    QVariantList items;
+    QVariantList  items;
     QDir::Filters filters = onlyDir ? QDir::Dirs : (QDir::Dirs | QDir::Files);
     filters |= QDir::NoDotAndDotDot;
 
     for (const QFileInfo& info : dir.entryInfoList(filters)) {
         QVariantMap item;
-        item["name"] = info.fileName();
+        item["name"]  = info.fileName();
         item["mtime"] = static_cast<qint64>(info.lastModified().toSecsSinceEpoch());
         items.append(item);
     }
@@ -145,19 +145,19 @@ QVariantMap FileHelper::getFolderList(const QString& path, const QVariantMap& op
 
 QVariantMap FileHelper::readWallpaperConfig(const QString& id) {
     QString filePath = wallpaperConfigFile(id);
-    QFile file(filePath);
+    QFile   file(filePath);
 
-    if (!file.exists()) {
+    if (! file.exists()) {
         return QVariantMap();
     }
 
-    if (!file.open(QIODevice::ReadOnly)) {
+    if (! file.open(QIODevice::ReadOnly)) {
         qWarning() << "FileHelper: Cannot read config:" << filePath;
         return QVariantMap();
     }
 
     QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-    if (doc.isNull() || !doc.isObject()) {
+    if (doc.isNull() || ! doc.isObject()) {
         return QVariantMap();
     }
 
@@ -175,9 +175,9 @@ void FileHelper::writeWallpaperConfig(const QString& id, const QVariantMap& chan
 
     // Write back
     QString filePath = wallpaperConfigFile(id);
-    QFile file(filePath);
+    QFile   file(filePath);
 
-    if (!file.open(QIODevice::WriteOnly)) {
+    if (! file.open(QIODevice::WriteOnly)) {
         qWarning() << "FileHelper: Cannot write config:" << filePath;
         return;
     }

--- a/src/FileHelper.cpp
+++ b/src/FileHelper.cpp
@@ -57,24 +57,6 @@ qint64 FileHelper::getDirSize(const QString& path, int depth) {
             totalSize += it.fileInfo().size();
         }
     } else {
-        // Limited depth iteration
-        for (int d = 1; d <= depth; ++d) {
-            QString pattern;
-            for (int i = 0; i < d; ++i) {
-                pattern += "*/";
-            }
-            pattern.chop(1); // Remove trailing /
-
-            QDirIterator it(path, QStringList() << "*", QDir::Files);
-            if (d == 1) {
-                while (it.hasNext()) {
-                    it.next();
-                    totalSize += it.fileInfo().size();
-                }
-            }
-        }
-
-        // Simpler approach: just iterate with depth limit
         std::function<qint64(const QString&, int)> calcSize = [&](const QString& dirPath,
                                                                   int currentDepth) -> qint64 {
             if (currentDepth > depth) return 0;

--- a/src/FileHelper.hpp
+++ b/src/FileHelper.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <QObject>
 #include <QString>
-#include <QUrl>
 #include <QVariantMap>
 #include <QVariantList>
 

--- a/src/FileHelper.hpp
+++ b/src/FileHelper.hpp
@@ -5,7 +5,8 @@
 #include <QVariantMap>
 #include <QVariantList>
 
-namespace wekde {
+namespace wekde
+{
 
 class FileHelper : public QObject {
     Q_OBJECT
@@ -15,14 +16,14 @@ public:
     virtual ~FileHelper();
 
     // File operations
-    Q_INVOKABLE QByteArray readFile(const QString& path);
-    Q_INVOKABLE qint64 getDirSize(const QString& path, int depth = 3);
+    Q_INVOKABLE QByteArray  readFile(const QString& path);
+    Q_INVOKABLE qint64      getDirSize(const QString& path, int depth = 3);
     Q_INVOKABLE QVariantMap getFolderList(const QString& path, const QVariantMap& opt = {});
 
     // Wallpaper config operations
     Q_INVOKABLE QVariantMap readWallpaperConfig(const QString& id);
-    Q_INVOKABLE void writeWallpaperConfig(const QString& id, const QVariantMap& changed);
-    Q_INVOKABLE void resetWallpaperConfig(const QString& id);
+    Q_INVOKABLE void        writeWallpaperConfig(const QString& id, const QVariantMap& changed);
+    Q_INVOKABLE void        resetWallpaperConfig(const QString& id);
 
 private:
     QString configDir() const;

--- a/src/MouseGrabber.cpp
+++ b/src/MouseGrabber.cpp
@@ -67,7 +67,7 @@ void MouseGrabber::sendMouseEvent(QMouseEvent* event) {
 void MouseGrabber::sendHoverEvent(QHoverEvent* event) {
     if (m_target) {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-        auto newPos = mapToItem(m_target, event->position());
+        auto        newPos = mapToItem(m_target, event->position());
         QHoverEvent temp(event->type(),
                          newPos,
                          event->globalPosition(),

--- a/src/MouseGrabber.hpp
+++ b/src/MouseGrabber.hpp
@@ -8,40 +8,39 @@
 namespace wekde
 {
 
-class MouseGrabber : public QQuickItem
-{
+class MouseGrabber : public QQuickItem {
     Q_OBJECT
-	Q_PROPERTY(bool forceCapture READ forceCapture WRITE setForceCapture NOTIFY forceCaptureChanged)
-	Q_PROPERTY(QQuickItem* target READ target WRITE setTarget NOTIFY targetChanged)
+    Q_PROPERTY(bool forceCapture READ forceCapture WRITE setForceCapture NOTIFY forceCaptureChanged)
+    Q_PROPERTY(QQuickItem* target READ target WRITE setTarget NOTIFY targetChanged)
 
 public:
-	MouseGrabber(QQuickItem *parent = nullptr);
-	virtual ~MouseGrabber() override {};
+    MouseGrabber(QQuickItem* parent = nullptr);
+    virtual ~MouseGrabber() override {};
 
-	bool forceCapture() const;
-	QQuickItem* target() const; 
+    bool        forceCapture() const;
+    QQuickItem* target() const;
 
-	void setForceCapture(bool);
-	void setTarget(QQuickItem*);
+    void setForceCapture(bool);
+    void setTarget(QQuickItem*);
 
-	Q_INVOKABLE void sendEvent(QObject*, QEvent*);
+    Q_INVOKABLE void sendEvent(QObject*, QEvent*);
 
 protected:
-	void mouseUngrabEvent() override;
-	void mousePressEvent(QMouseEvent*) override;
-	void mouseMoveEvent(QMouseEvent*) override;
-	void mouseReleaseEvent(QMouseEvent *) override;
-	void mouseDoubleClickEvent(QMouseEvent *) override;
-	void hoverMoveEvent(QHoverEvent *) override;
+    void mouseUngrabEvent() override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+    void mouseDoubleClickEvent(QMouseEvent*) override;
+    void hoverMoveEvent(QHoverEvent*) override;
 
 signals:
-	void forceCaptureChanged();
-	void targetChanged();
+    void forceCaptureChanged();
+    void targetChanged();
 
 private:
-    void sendMouseEvent(QMouseEvent*);
-    void sendHoverEvent(QHoverEvent*);
-	bool m_forceCapture {false};
-    QPointer<QQuickItem> m_target {nullptr};
+    void                 sendMouseEvent(QMouseEvent*);
+    void                 sendHoverEvent(QHoverEvent*);
+    bool                 m_forceCapture { false };
+    QPointer<QQuickItem> m_target { nullptr };
 };
-}
+} // namespace wekde

--- a/src/TTYSwitchMonitor.cpp
+++ b/src/TTYSwitchMonitor.cpp
@@ -3,24 +3,21 @@
 
 using namespace wekde;
 
-TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
-    : QQuickItem(parent), m_sleeping(false) {
+TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem* parent): QQuickItem(parent), m_sleeping(false) {
     QDBusConnection systemBus = QDBusConnection::systemBus();
-    if (!systemBus.isConnected()) {
+    if (! systemBus.isConnected()) {
         qFatal("Cannot connect to the D-Bus system bus");
         return;
     }
 
-    bool connected = systemBus.connect(
-        "org.freedesktop.login1",
-        "/org/freedesktop/login1",
-        "org.freedesktop.login1.Manager",
-        "PrepareForSleep",
-        this,
-        SLOT(handlePrepareForSleep(bool))
-    );
+    bool connected = systemBus.connect("org.freedesktop.login1",
+                                       "/org/freedesktop/login1",
+                                       "org.freedesktop.login1.Manager",
+                                       "PrepareForSleep",
+                                       this,
+                                       SLOT(handlePrepareForSleep(bool)));
 
-    if (!connected) {
+    if (! connected) {
         qFatal("Failed to connect to PrepareForSleep signal");
     }
 }

--- a/src/TTYSwitchMonitor.hpp
+++ b/src/TTYSwitchMonitor.hpp
@@ -2,14 +2,15 @@
 #include <QQuickItem>
 #include <QDBusConnection>
 
-namespace wekde {
+namespace wekde
+{
 
 class TTYSwitchMonitor : public QQuickItem {
     Q_OBJECT
     Q_PROPERTY(bool sleeping READ isSleeping NOTIFY ttySwitch)
 
 public:
-    TTYSwitchMonitor(QQuickItem *parent = nullptr);
+    TTYSwitchMonitor(QQuickItem* parent = nullptr);
 
     bool isSleeping() const { return m_sleeping; }
 
@@ -23,4 +24,4 @@ private:
     bool m_sleeping;
 };
 
-}
+} // namespace wekde

--- a/src/backend_mpv/MpvBackend.cpp
+++ b/src/backend_mpv/MpvBackend.cpp
@@ -8,20 +8,20 @@
 #include <QtGui/QGuiApplication>
 #include <QtGui/QOpenGLContext>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QtOpenGL/QOpenGLFramebufferObject>
+#    include <QtOpenGL/QOpenGLFramebufferObject>
 #else
-#include <QtGui/QOpenGLFramebufferObject>
+#    include <QtGui/QOpenGLFramebufferObject>
 #endif
 #include <QtGui/QOpenGLFunctions>
 #include <QtQuick/QQuickWindow>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QtQuick/QQuickOpenGLUtils>
+#    include <QtQuick/QQuickOpenGLUtils>
 #endif
 
 #include <QtGui/QOffscreenSurface>
 #include <QtQuick/QSGSimpleTextureNode>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QSGTexture>
+#    include <QSGTexture>
 #endif
 
 #include <clocale>
@@ -32,14 +32,14 @@
 #include <sys/stat.h>
 
 #if defined(__linux__) || defined(__FreeBSD__)
-//#ifdef ENABLE_X11
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-#    include <QX11Info> // IWYU pragma: keep
-#elif (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
+// #ifdef ENABLE_X11
+#    if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#        include <QX11Info> // IWYU pragma: keep
+#    elif (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
 // Qt 6.0-6.4: use platformNativeInterface for X11 (6.0-6.1) and Wayland (6.0-6.4)
-#    include <qpa/qplatformnativeinterface.h>
-#endif
-//#endif
+#        include <qpa/qplatformnativeinterface.h>
+#    endif
+// #endif
 #endif
 
 Q_LOGGING_CATEGORY(wekdeMpv, "wekde.mpv")
@@ -82,27 +82,27 @@ int CreateMpvContex(mpv_handle* mpv, mpv_render_context** mpv_gl) {
 #if defined(__linux__) || defined(__FreeBSD__)
     if (QGuiApplication::platformName().contains("xcb")) {
         params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
+#    if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
         if (auto* x11App = qGuiApp->nativeInterface<QNativeInterface::QX11Application>()) {
             params[2].data = x11App->display();
         }
-#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#    elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         auto* native   = QGuiApplication::platformNativeInterface();
         params[2].data = native->nativeResourceForWindow("display", nullptr);
-#else
+#    else
         params[2].data = QX11Info::display();
-#endif
+#    endif
     }
     if (QGuiApplication::platformName().contains("wayland")) {
         params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+#    if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
         if (auto* waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>()) {
             params[2].data = waylandApp->display();
         }
-#else
+#    else
         auto* native   = QGuiApplication::platformNativeInterface();
         params[2].data = native->nativeResourceForWindow("display", nullptr);
-#endif
+#    endif
     }
 #endif
     int code = mpv_render_context_create(mpv_gl, mpv, params);

--- a/src/backend_mpv/qthelper.hpp
+++ b/src/backend_mpv/qthelper.hpp
@@ -12,18 +12,20 @@
 #include <QSharedPointer>
 #include <QMetaType>
 
-namespace mpv {
-namespace qt {
+namespace mpv
+{
+namespace qt
+{
 
 // Wrapper around mpv_handle. Does refcounting under the hood.
-class Handle
-{
+class Handle {
     struct container {
-        explicit container(mpv_handle *h) : mpv(h) {}
+        explicit container(mpv_handle* h): mpv(h) {}
         ~container() { mpv_terminate_destroy(mpv); }
-        mpv_handle *mpv;
+        mpv_handle* mpv;
     };
     QSharedPointer<container> sptr;
+
 public:
     // Construct a new Handle from a raw mpv_handle with refcount 1. If the
     // last Handle goes out of scope, the mpv_handle will be destroyed with
@@ -33,7 +35,7 @@ public:
     // destroying the mpv_handle.
     // Never create multiple wrappers from the same raw mpv_handle; copy the
     // wrapper instead (that's what it's for).
-    static Handle FromRawHandle(mpv_handle *handle) {
+    static Handle FromRawHandle(mpv_handle* handle) {
         Handle h;
         h.sptr = QSharedPointer<container>(new container(handle));
         return h;
@@ -43,30 +45,23 @@ public:
     operator mpv_handle*() const { return sptr ? (*sptr).mpv : nullptr; }
 };
 
-static inline QVariant node_to_variant(const mpv_node *node)
-{
+static inline QVariant node_to_variant(const mpv_node* node) {
     switch (node->format) {
-    case MPV_FORMAT_STRING:
-        return QVariant(QString::fromUtf8(node->u.string));
-    case MPV_FORMAT_FLAG:
-        return QVariant(static_cast<bool>(node->u.flag));
-    case MPV_FORMAT_INT64:
-        return QVariant(static_cast<qlonglong>(node->u.int64));
-    case MPV_FORMAT_DOUBLE:
-        return QVariant(node->u.double_);
+    case MPV_FORMAT_STRING: return QVariant(QString::fromUtf8(node->u.string));
+    case MPV_FORMAT_FLAG: return QVariant(static_cast<bool>(node->u.flag));
+    case MPV_FORMAT_INT64: return QVariant(static_cast<qlonglong>(node->u.int64));
+    case MPV_FORMAT_DOUBLE: return QVariant(node->u.double_);
     case MPV_FORMAT_NODE_ARRAY: {
-        mpv_node_list *list = node->u.list;
-        QVariantList qlist;
-        for (int n = 0; n < list->num; n++)
-            qlist.append(node_to_variant(&list->values[n]));
+        mpv_node_list* list = node->u.list;
+        QVariantList   qlist;
+        for (int n = 0; n < list->num; n++) qlist.append(node_to_variant(&list->values[n]));
         return QVariant(qlist);
     }
     case MPV_FORMAT_NODE_MAP: {
-        mpv_node_list *list = node->u.list;
-        QVariantMap qmap;
+        mpv_node_list* list = node->u.list;
+        QVariantMap    qmap;
         for (int n = 0; n < list->num; n++) {
-            qmap.insert(QString::fromUtf8(list->keys[n]),
-                        node_to_variant(&list->values[n]));
+            qmap.insert(QString::fromUtf8(list->keys[n]), node_to_variant(&list->values[n]));
         }
         return QVariant(qmap);
     }
@@ -76,40 +71,34 @@ static inline QVariant node_to_variant(const mpv_node *node)
 }
 
 struct node_builder {
-    explicit node_builder(const QVariant& v)
-        : node_() {
-        set(&node_, v);
-    }
-    ~node_builder() {
-        free_node(&node_);
-    }
-    mpv_node *node() { return &node_; }
+    explicit node_builder(const QVariant& v): node_() { set(&node_, v); }
+    ~node_builder() { free_node(&node_); }
+    mpv_node* node() { return &node_; }
+
 private:
     Q_DISABLE_COPY(node_builder)
     mpv_node node_;
 
-    mpv_node_list *create_list(mpv_node *dst, bool is_map, int num) {
+    mpv_node_list* create_list(mpv_node* dst, bool is_map, int num) {
         dst->format = is_map ? MPV_FORMAT_NODE_MAP : MPV_FORMAT_NODE_ARRAY;
         try {
-            mpv_node_list *list = new mpv_node_list();
-            dst->u.list = list;
-            list->values = new mpv_node[num]();
-            if (is_map)
-                list->keys = new char *[num]();
+            mpv_node_list* list = new mpv_node_list();
+            dst->u.list         = list;
+            list->values        = new mpv_node[num]();
+            if (is_map) list->keys = new char*[num]();
             return list;
-        }
-        catch (const std::bad_alloc &) {
+        } catch (const std::bad_alloc&) {
             free_node(dst);
             return nullptr;
         }
     }
-    char *dup_qstring(const QString &s) {
+    char* dup_qstring(const QString& s) {
         QByteArray b = s.toUtf8();
-        char *r = new char[b.size() + 1];
+        char*      r = new char[b.size() + 1];
         std::memcpy(r, b.data(), b.size() + 1);
         return r;
     }
-    bool test_type(const QVariant &v, QMetaType::Type t) {
+    bool test_type(const QVariant& v, QMetaType::Type t) {
         // The Qt docs say: "Although this function is declared as returning
         // "QVariant::Type(obsolete), the return value should be interpreted
         // as QMetaType::Type."
@@ -120,42 +109,35 @@ private:
         return static_cast<int>(v.type()) == static_cast<int>(t);
 #endif
     }
-    void set(mpv_node *dst, const QVariant &src) {
+    void set(mpv_node* dst, const QVariant& src) {
         if (test_type(src, QMetaType::QString)) {
-            dst->format = MPV_FORMAT_STRING;
+            dst->format   = MPV_FORMAT_STRING;
             dst->u.string = dup_qstring(src.toString());
-            if (!dst->u.string)
-                goto fail;
+            if (! dst->u.string) goto fail;
         } else if (test_type(src, QMetaType::Bool)) {
             dst->format = MPV_FORMAT_FLAG;
             dst->u.flag = src.toBool() ? 1 : 0;
-        } else if (test_type(src, QMetaType::Int) ||
-                   test_type(src, QMetaType::LongLong) ||
-                   test_type(src, QMetaType::UInt) ||
-                   test_type(src, QMetaType::ULongLong))
-        {
-            dst->format = MPV_FORMAT_INT64;
+        } else if (test_type(src, QMetaType::Int) || test_type(src, QMetaType::LongLong) ||
+                   test_type(src, QMetaType::UInt) || test_type(src, QMetaType::ULongLong)) {
+            dst->format  = MPV_FORMAT_INT64;
             dst->u.int64 = src.toLongLong();
         } else if (test_type(src, QMetaType::Double)) {
-            dst->format = MPV_FORMAT_DOUBLE;
+            dst->format    = MPV_FORMAT_DOUBLE;
             dst->u.double_ = src.toDouble();
         } else if (src.canConvert<QVariantList>()) {
-            QVariantList qlist = src.toList();
-            mpv_node_list *list = create_list(dst, false, qlist.size());
-            if (!list)
-                goto fail;
+            QVariantList   qlist = src.toList();
+            mpv_node_list* list  = create_list(dst, false, qlist.size());
+            if (! list) goto fail;
             list->num = qlist.size();
-            for (int n = 0; n < qlist.size(); n++)
-                set(&list->values[n], qlist[n]);
+            for (int n = 0; n < qlist.size(); n++) set(&list->values[n], qlist[n]);
         } else if (src.canConvert<QVariantMap>()) {
-            QVariantMap qmap = src.toMap();
-            mpv_node_list *list = create_list(dst, true, qmap.size());
-            if (!list)
-                goto fail;
+            QVariantMap    qmap = src.toMap();
+            mpv_node_list* list = create_list(dst, true, qmap.size());
+            if (! list) goto fail;
             list->num = qmap.size();
             for (int n = 0; n < qmap.size(); n++) {
                 list->keys[n] = dup_qstring(qmap.keys()[n]);
-                if (!list->keys[n]) {
+                if (! list->keys[n]) {
                     free_node(dst);
                     goto fail;
                 }
@@ -168,20 +150,16 @@ private:
     fail:
         dst->format = MPV_FORMAT_NONE;
     }
-    void free_node(mpv_node *dst) {
+    void free_node(mpv_node* dst) {
         switch (dst->format) {
-        case MPV_FORMAT_STRING:
-            delete[] dst->u.string;
-            break;
+        case MPV_FORMAT_STRING: delete[] dst->u.string; break;
         case MPV_FORMAT_NODE_ARRAY:
         case MPV_FORMAT_NODE_MAP: {
-            mpv_node_list *list = dst->u.list;
+            mpv_node_list* list = dst->u.list;
             if (list) {
                 for (int n = 0; n < list->num; n++) {
-                    if (list->keys)
-                        delete[] list->keys[n];
-                    if (list->values)
-                        free_node(&list->values[n]);
+                    if (list->keys) delete[] list->keys[n];
+                    if (list->values) free_node(&list->values[n]);
                 }
                 delete[] list->keys;
                 delete[] list->values;
@@ -189,7 +167,7 @@ private:
             delete list;
             break;
         }
-        default: ;
+        default:;
         }
         dst->format = MPV_FORMAT_NONE;
     }
@@ -199,8 +177,8 @@ private:
  * RAII wrapper that calls mpv_free_node_contents() on the pointer.
  */
 struct node_autofree {
-    mpv_node *ptr;
-    explicit node_autofree(mpv_node *a_ptr) : ptr(a_ptr) {}
+    mpv_node* ptr;
+    explicit node_autofree(mpv_node* a_ptr): ptr(a_ptr) {}
     ~node_autofree() { mpv_free_node_contents(ptr); }
 };
 
@@ -212,11 +190,9 @@ struct node_autofree {
  *
  * @param name the property name
  */
-static inline QVariant get_property_variant(mpv_handle *ctx, const QString &name)
-{
+static inline QVariant get_property_variant(mpv_handle* ctx, const QString& name) {
     mpv_node node;
-    if (mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node) < 0)
-        return QVariant();
+    if (mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node) < 0) return QVariant();
     node_autofree f(&node);
     return node_to_variant(&node);
 }
@@ -226,9 +202,7 @@ static inline QVariant get_property_variant(mpv_handle *ctx, const QString &name
 
  * @deprecated use set_property() instead
  */
-static inline int set_property_variant(mpv_handle *ctx, const QString &name,
-                                       const QVariant &v)
-{
+static inline int set_property_variant(mpv_handle* ctx, const QString& name, const QVariant& v) {
     node_builder node(v);
     return mpv_set_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, node.node());
 }
@@ -238,9 +212,7 @@ static inline int set_property_variant(mpv_handle *ctx, const QString &name,
  *
  * @deprecated use set_property() instead
  */
-static inline int set_option_variant(mpv_handle *ctx, const QString &name,
-                                     const QVariant &v)
-{
+static inline int set_option_variant(mpv_handle* ctx, const QString& name, const QVariant& v) {
     node_builder node(v);
     return mpv_set_option(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, node.node());
 }
@@ -251,12 +223,10 @@ static inline int set_option_variant(mpv_handle *ctx, const QString &name,
  *
  * @deprecated use command() instead
  */
-static inline QVariant command_variant(mpv_handle *ctx, const QVariant &args)
-{
+static inline QVariant command_variant(mpv_handle* ctx, const QVariant& args) {
     node_builder node(args);
-    mpv_node res;
-    if (mpv_command_node(ctx, node.node(), &res) < 0)
-        return QVariant();
+    mpv_node     res;
+    if (mpv_command_node(ctx, node.node(), &res) < 0) return QVariant();
     node_autofree f(&res);
     return node_to_variant(&res);
 }
@@ -268,15 +238,14 @@ static inline QVariant command_variant(mpv_handle *ctx, const QVariant &args)
  * You can use get_error() or is_error() to extract the error status from a
  * QVariant value.
  */
-struct ErrorReturn
-{
+struct ErrorReturn {
     /**
      * enum mpv_error value (or a value outside of it if ABI was extended)
      */
     int error;
 
-    ErrorReturn() : error(0) {}
-    explicit ErrorReturn(int err) : error(err) {}
+    ErrorReturn(): error(0) {}
+    explicit ErrorReturn(int err): error(err) {}
 };
 
 /**
@@ -285,20 +254,15 @@ struct ErrorReturn
  *
  * @return error code (<0) or success (>=0)
  */
-static inline int get_error(const QVariant &v)
-{
-    if (!v.canConvert<ErrorReturn>())
-        return 0;
+static inline int get_error(const QVariant& v) {
+    if (! v.canConvert<ErrorReturn>()) return 0;
     return v.value<ErrorReturn>().error;
 }
 
 /**
  * Return whether the QVariant carries a mpv error code.
  */
-static inline bool is_error(const QVariant &v)
-{
-    return get_error(v) < 0;
-}
+static inline bool is_error(const QVariant& v) { return get_error(v) < 0; }
 
 /**
  * Return the given property as mpv_node converted to QVariant, or QVariant()
@@ -307,12 +271,10 @@ static inline bool is_error(const QVariant &v)
  * @param name the property name
  * @return the property value, or an ErrorReturn with the error code
  */
-static inline QVariant get_property(mpv_handle *ctx, const QString &name)
-{
+static inline QVariant get_property(mpv_handle* ctx, const QString& name) {
     mpv_node node;
-    int err = mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node);
-    if (err < 0)
-        return QVariant::fromValue(ErrorReturn(err));
+    int      err = mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node);
+    if (err < 0) return QVariant::fromValue(ErrorReturn(err));
     node_autofree f(&node);
     return node_to_variant(&node);
 }
@@ -322,9 +284,7 @@ static inline QVariant get_property(mpv_handle *ctx, const QString &name)
  *
  * @return mpv error code (<0 on error, >= 0 on success)
  */
-static inline int set_property(mpv_handle *ctx, const QString &name,
-                                       const QVariant &v)
-{
+static inline int set_property(mpv_handle* ctx, const QString& name, const QVariant& v) {
     node_builder node(v);
     return mpv_set_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, node.node());
 }
@@ -335,19 +295,17 @@ static inline int set_property(mpv_handle *ctx, const QString &name,
  * @param args command arguments, with args[0] being the command name as string
  * @return the property value, or an ErrorReturn with the error code
  */
-static inline QVariant command(mpv_handle *ctx, const QVariant &args)
-{
+static inline QVariant command(mpv_handle* ctx, const QVariant& args) {
     node_builder node(args);
-    mpv_node res;
-    int err = mpv_command_node(ctx, node.node(), &res);
-    if (err < 0)
-        return QVariant::fromValue(ErrorReturn(err));
+    mpv_node     res;
+    int          err = mpv_command_node(ctx, node.node(), &res);
+    if (err < 0) return QVariant::fromValue(ErrorReturn(err));
     node_autofree f(&res);
     return node_to_variant(&res);
 }
 
-}
-}
+} // namespace qt
+} // namespace mpv
 
 Q_DECLARE_METATYPE(mpv::qt::ErrorReturn)
 

--- a/src/backend_mpv/standalone_viewer/qmlviewer.cpp
+++ b/src/backend_mpv/standalone_viewer/qmlviewer.cpp
@@ -7,22 +7,21 @@
 #include <string>
 #include "MpvBackend.hpp"
 
-int main(int argc, char **argv)
-{
-	if(argc != 2) {
-		std::cerr << "usage: "+ std::string(argv[0]) +" <video file>\n";
-		return 1;
-	}
-	QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "usage: " + std::string(argv[0]) + " <video file>\n";
+        return 1;
+    }
+    QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
     QGuiApplication app(argc, argv);
-	qmlRegisterType<mpv::MpvObject>("mpvtest", 1, 0, "MpvObject");
-	setlocale(LC_NUMERIC, "C");
+    qmlRegisterType<mpv::MpvObject>("mpvtest", 1, 0, "MpvObject");
+    setlocale(LC_NUMERIC, "C");
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
     view.setSource(QUrl("qrc:///qml/main.qml"));
     view.show();
-	QObject *obj = view.rootObject();
-	mpv::MpvObject* mpv = obj->findChild<mpv::MpvObject *>();
-	mpv->setSource(QUrl::fromLocalFile(argv[1]));
+    QObject*        obj = view.rootObject();
+    mpv::MpvObject* mpv = obj->findChild<mpv::MpvObject*>();
+    mpv->setSource(QUrl::fromLocalFile(argv[1]));
     return app.exec();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Can be built standalone:  cmake -B build/tests -S tests
+# Or included from root with: -DBUILD_TESTS=ON
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    cmake_minimum_required(VERSION 3.16)
+    project(WallpaperEngineKdeTests CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+    enable_testing()
+    set(WEKDE_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src")
+else()
+    set(WEKDE_SRC_DIR "${CMAKE_SOURCE_DIR}/src")
+endif()
+
+find_package(Qt6 REQUIRED COMPONENTS Core Test)
+set(CMAKE_AUTOMOC ON)
+
+# ── FileHelper unit tests ──────────────────────────────────────────────────────
+add_executable(tst_filehelper
+    tst_filehelper.cpp
+    ${WEKDE_SRC_DIR}/FileHelper.cpp
+)
+target_include_directories(tst_filehelper PRIVATE ${WEKDE_SRC_DIR})
+target_link_libraries(tst_filehelper PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME tst_filehelper COMMAND tst_filehelper -v2)

--- a/tests/tst_filehelper.cpp
+++ b/tests/tst_filehelper.cpp
@@ -2,10 +2,7 @@
 // Unit tests for wekde::FileHelper
 //
 // getDirSize behaviour note (depth > 0):
-//   The loop at FileHelper.cpp:62-76 accumulates into totalSize but is then
-//   immediately overwritten by `totalSize = calcSize(path, 1)` at line 98.
-//   That loop is therefore dead code; only calcSize() determines the result.
-//   calcSize starts at currentDepth=1 and recurses while currentDepth < depth,
+//   calcSize() starts at currentDepth=1 and recurses while currentDepth < depth,
 //   so depth=N counts files up to N directory levels from the root.
 
 #include <QtTest>

--- a/tests/tst_filehelper.cpp
+++ b/tests/tst_filehelper.cpp
@@ -258,6 +258,25 @@ private slots:
         QVERIFY(helper.readWallpaperConfig("__no_such_wallpaper__").isEmpty());
     }
 
+    void config_readCorruptJson_returnsEmpty() {
+        // Write a file with invalid JSON directly into the config dir so that
+        // readWallpaperConfig finds it but QJsonDocument::fromJson returns null.
+        FileHelper helper;
+        const QString id = "test_corrupt";
+        const QString path =
+            QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
+            + "/wekde/wallpaper/" + id + ".json";
+        QDir().mkpath(QFileInfo(path).absolutePath());
+        QFile f(path);
+        QVERIFY(f.open(QIODevice::WriteOnly));
+        f.write("not valid json {{{");
+        f.close();
+
+        QVERIFY(helper.readWallpaperConfig(id).isEmpty());
+
+        QFile::remove(path);
+    }
+
     void config_writeAndRead_roundTrip() {
         FileHelper helper;
         const QString id = "test_roundtrip";

--- a/tests/tst_filehelper.cpp
+++ b/tests/tst_filehelper.cpp
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Unit tests for wekde::FileHelper
+//
+// getDirSize behaviour note (depth > 0):
+//   The loop at FileHelper.cpp:62-76 accumulates into totalSize but is then
+//   immediately overwritten by `totalSize = calcSize(path, 1)` at line 98.
+//   That loop is therefore dead code; only calcSize() determines the result.
+//   calcSize starts at currentDepth=1 and recurses while currentDepth < depth,
+//   so depth=N counts files up to N directory levels from the root.
+
+#include <QtTest>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QVariantList>
+#include <QVariantMap>
+
+#include "FileHelper.hpp"
+
+using namespace wekde;
+
+class TestFileHelper : public QObject {
+    Q_OBJECT
+
+private:
+    QTemporaryDir m_tmp;
+
+    // Write `size` bytes to `filePath`; returns true on success.
+    static bool writeBytes(const QString& filePath, int size, char fill = 'x') {
+        QFile f(filePath);
+        if (!f.open(QIODevice::WriteOnly)) return false;
+        f.write(QByteArray(size, fill));
+        return true;
+    }
+
+private slots:
+    // ── test-suite setup / teardown ───────────────────────────────────────────
+    void initTestCase() {
+        // Redirect QStandardPaths to a safe test location so tests never
+        // touch the real user config directory.
+        QStandardPaths::setTestModeEnabled(true);
+        QVERIFY2(m_tmp.isValid(), "Could not create temporary directory for tests");
+    }
+
+    void cleanupTestCase() {
+        QString testCfg =
+            QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/wekde";
+        QDir(testCfg).removeRecursively();
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+    // ── readFile ──────────────────────────────────────────────────────────────
+    void readFile_existingFile() {
+        QTemporaryFile f(m_tmp.filePath("read_XXXXXX"));
+        f.setAutoRemove(false);
+        QVERIFY(f.open());
+        f.write("hello world");
+        f.close();
+
+        FileHelper helper;
+        QCOMPARE(helper.readFile(f.fileName()), QByteArray("hello world"));
+    }
+
+    void readFile_nonExistentFile() {
+        FileHelper helper;
+        QByteArray result = helper.readFile("/tmp/wekde_test_nonexistent_file_xyz.txt");
+        QVERIFY(result.isEmpty());
+    }
+
+    void readFile_emptyFile() {
+        QTemporaryFile f(m_tmp.filePath("empty_XXXXXX"));
+        QVERIFY(f.open());
+        f.close(); // zero bytes
+
+        FileHelper helper;
+        QVERIFY(helper.readFile(f.fileName()).isEmpty());
+    }
+
+    void readFile_binaryContent() {
+        QByteArray binary;
+        for (int i = 0; i < 256; ++i) binary.append(static_cast<char>(i));
+
+        QTemporaryFile f(m_tmp.filePath("bin_XXXXXX"));
+        f.setAutoRemove(false);
+        QVERIFY(f.open());
+        f.write(binary);
+        f.close();
+
+        FileHelper helper;
+        QCOMPARE(helper.readFile(f.fileName()), binary);
+    }
+
+    // ── getDirSize ────────────────────────────────────────────────────────────
+    void getDirSize_nonExistentDir() {
+        FileHelper helper;
+        QCOMPARE(helper.getDirSize("/tmp/wekde_test_nonexistent_dir_xyz"), qint64(0));
+    }
+
+    void getDirSize_emptyDir() {
+        QTemporaryDir d;
+        FileHelper helper;
+        QCOMPARE(helper.getDirSize(d.path()), qint64(0));
+    }
+
+    void getDirSize_topLevelFiles_depth1() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("a.txt"), 100));
+        QVERIFY(writeBytes(d.filePath("b.txt"), 150));
+
+        FileHelper helper;
+        QCOMPARE(helper.getDirSize(d.path(), 1), qint64(250));
+    }
+
+    void getDirSize_depth1_ignoresSubdirFiles() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("root.txt"), 100));
+        QVERIFY(d.path().length() > 0);
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("sub/sub.txt"), 200));
+
+        FileHelper helper;
+        // depth=1 → only root files counted
+        QCOMPARE(helper.getDirSize(d.path(), 1), qint64(100));
+    }
+
+    void getDirSize_depth2_includesOneLevel() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("root.txt"), 100));
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("sub/sub.txt"), 200));
+        QDir(d.filePath("sub")).mkdir("subsub");
+        QVERIFY(writeBytes(d.filePath("sub/subsub/deep.txt"), 300));
+
+        FileHelper helper;
+        // depth=2 → root + immediate subdir, NOT sub/subsub
+        QCOMPARE(helper.getDirSize(d.path(), 2), qint64(300));
+    }
+
+    void getDirSize_depth3_includesTwoLevels() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("root.txt"), 100));
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("sub/sub.txt"), 200));
+        QDir(d.filePath("sub")).mkdir("subsub");
+        QVERIFY(writeBytes(d.filePath("sub/subsub/deep.txt"), 300));
+
+        FileHelper helper;
+        // depth=3 (default) → root + sub + sub/subsub
+        QCOMPARE(helper.getDirSize(d.path(), 3), qint64(600));
+    }
+
+    void getDirSize_unlimitedDepth() {
+        QTemporaryDir d;
+        // Create a 4-level-deep file (beyond default depth=3)
+        QDir r(d.path());
+        QVERIFY(r.mkpath("a/b/c/d"));
+        QVERIFY(writeBytes(d.filePath("a/b/c/d/deep.txt"), 500));
+
+        FileHelper helper;
+        // depth=0 → unlimited; must find the file no matter how deep
+        QCOMPARE(helper.getDirSize(d.path(), 0), qint64(500));
+    }
+
+    // ── getFolderList ─────────────────────────────────────────────────────────
+    void getFolderList_nonExistentDirNoFallback() {
+        FileHelper helper;
+        QVariantMap result = helper.getFolderList("/tmp/wekde_test_nodir_xyz");
+        QVERIFY(result.isEmpty());
+    }
+
+    void getFolderList_existingDir_returnsItems() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("wallA");
+        QDir(d.path()).mkdir("wallB");
+
+        FileHelper helper;
+        QVariantMap result = helper.getFolderList(d.path());
+        QVERIFY(!result.isEmpty());
+        QCOMPARE(result["folder"].toString(), d.path());
+
+        QVariantList items = result["items"].toList();
+        QCOMPARE(items.size(), 2);
+
+        // Each item must have "name" and numeric "mtime"
+        for (const QVariant& v : items) {
+            QVariantMap item = v.toMap();
+            QVERIFY(item.contains("name"));
+            QVERIFY(item.contains("mtime"));
+            QVERIFY(item["mtime"].toLongLong() > 0);
+        }
+    }
+
+    void getFolderList_fallbackUsedWhenPrimaryMissing() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("fallback");
+
+        FileHelper helper;
+        QVariantMap opts;
+        opts["fallbacks"] = QStringList{d.filePath("fallback")};
+
+        QVariantMap result = helper.getFolderList("/tmp/wekde_test_nodir_xyz", opts);
+        QVERIFY(!result.isEmpty());
+        QCOMPARE(result["folder"].toString(), d.filePath("fallback"));
+    }
+
+    void getFolderList_firstValidFallbackChosen() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("second");
+
+        FileHelper helper;
+        QVariantMap opts;
+        // first fallback does not exist; second does
+        opts["fallbacks"] =
+            QStringList{"/tmp/wekde_no_such_dir_1", d.filePath("second")};
+
+        QVariantMap result = helper.getFolderList("/tmp/wekde_no_such_dir_2", opts);
+        QVERIFY(!result.isEmpty());
+        QCOMPARE(result["folder"].toString(), d.filePath("second"));
+    }
+
+    void getFolderList_onlyDir_true_excludesFiles() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("file.txt"), 1));
+
+        FileHelper helper;
+        // Default: only_dir=true
+        QVariantMap result = helper.getFolderList(d.path());
+        QVariantList items = result["items"].toList();
+        QCOMPARE(items.size(), 1);
+        QCOMPARE(items[0].toMap()["name"].toString(), QString("sub"));
+    }
+
+    void getFolderList_onlyDir_false_includesFiles() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("file.txt"), 1));
+
+        FileHelper helper;
+        QVariantMap opts;
+        opts["only_dir"] = false;
+
+        QVariantMap result = helper.getFolderList(d.path(), opts);
+        QVariantList items = result["items"].toList();
+        QCOMPARE(items.size(), 2);
+    }
+
+    void getFolderList_emptyDir_returnsEmptyItems() {
+        QTemporaryDir d;
+        FileHelper helper;
+        QVariantMap result = helper.getFolderList(d.path());
+        QVERIFY(!result.isEmpty());
+        QVERIFY(result["items"].toList().isEmpty());
+    }
+
+    // ── wallpaper config round-trip ───────────────────────────────────────────
+    void config_readNonExistent_returnsEmpty() {
+        FileHelper helper;
+        QVERIFY(helper.readWallpaperConfig("__no_such_wallpaper__").isEmpty());
+    }
+
+    void config_writeAndRead_roundTrip() {
+        FileHelper helper;
+        const QString id = "test_roundtrip";
+
+        QVariantMap cfg;
+        cfg["volume"] = 75;
+        cfg["fps"]    = 30;
+        cfg["mute"]   = false;
+        helper.writeWallpaperConfig(id, cfg);
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["volume"].toInt(), 75);
+        QCOMPARE(got["fps"].toInt(), 30);
+        QCOMPARE(got["mute"].toBool(), false);
+
+        helper.resetWallpaperConfig(id);
+    }
+
+    void config_write_mergesPreviousValues() {
+        FileHelper helper;
+        const QString id = "test_merge";
+
+        helper.writeWallpaperConfig(id, {{"volume", 50}, {"fps", 60}});
+
+        // Partial update: only change volume
+        helper.writeWallpaperConfig(id, {{"volume", 80}});
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["volume"].toInt(), 80);
+        QCOMPARE(got["fps"].toInt(), 60); // unchanged
+
+        helper.resetWallpaperConfig(id);
+    }
+
+    void config_write_addsNewKey() {
+        FileHelper helper;
+        const QString id = "test_newkey";
+
+        helper.writeWallpaperConfig(id, {{"a", 1}});
+        helper.writeWallpaperConfig(id, {{"b", 2}});
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["a"].toInt(), 1);
+        QCOMPARE(got["b"].toInt(), 2);
+
+        helper.resetWallpaperConfig(id);
+    }
+
+    void config_reset_removesConfig() {
+        FileHelper helper;
+        const QString id = "test_reset";
+
+        helper.writeWallpaperConfig(id, {{"key", "value"}});
+        QVERIFY(!helper.readWallpaperConfig(id).isEmpty());
+
+        helper.resetWallpaperConfig(id);
+        QVERIFY(helper.readWallpaperConfig(id).isEmpty());
+    }
+
+    void config_reset_nonExistent_noError() {
+        FileHelper helper;
+        // Resetting a config that was never written must not crash or throw
+        helper.resetWallpaperConfig("__never_existed__");
+        QVERIFY(helper.readWallpaperConfig("__never_existed__").isEmpty());
+    }
+
+    void config_stringValues_preserved() {
+        FileHelper helper;
+        const QString id = "test_strings";
+
+        helper.writeWallpaperConfig(id, {{"name", "My Wallpaper"}, {"path", "/some/path"}});
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["name"].toString(), QString("My Wallpaper"));
+        QCOMPARE(got["path"].toString(), QString("/some/path"));
+
+        helper.resetWallpaperConfig(id);
+    }
+};
+
+QTEST_MAIN(TestFileHelper)
+#include "tst_filehelper.moc"


### PR DESCRIPTION
Updates the RPM spec file to work with this fork and modern Fedora (tested on Fedora 43 / Bazzite).

Updated URL to RainyPixel fork
Dropped python3-websockets runtime dependency (removed in this fork)
Dropped qt5-qtx11extras-devel (Qt5 package, not needed for Qt6 build)
Fixed qt6-qtwebchannel-devel / qt6-qtwebsockets-devel moved to BuildRequires only; runtime Requires now correctly uses non-devel packages
Added missing kf6-kcoreaddons-devel and kf6-kpackage-devel to BuildRequires
Modernised cmake invocation (cmake -B/cmake --build/DESTDIR= cmake --install)
Removed %setup and source tarball dependency — spec now builds directly from git checkout
Added --define="reporoot $(pwd)" pattern for rpmbuild invocation

Tested on: Fedora 43 (Bazzite using Distrobox), KDE Plasma 6.5.5, Qt 6.10.1, KDE Frameworks 6.22.0

```
sudo dnf install -y \
    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm

sudo dnf swap -y ffmpeg-free ffmpeg --allowerasing
sudo dnf install -y ffmpeg-devel --allowerasing

sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel gstreamer1-libav \
lz4-devel mpv-libs-devel qt6-qtbase-private-devel libplasma-devel \
qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake extra-cmake-modules

cd ./wallpaper-engine-kde-plugin

sudo dnf builddep ./rpm/wek.spec

git submodule update --init --force --recursive

cp -R ./plugin/* ~/.local/share/plasma/wallpapers/com.github.catsout.wallpaperEngineKde/

sudo mount -t tmpfs tmpfs ~/rpmbuild/BUILD

rpmbuild --define="commit $(git rev-parse HEAD)" \
    --define="reporoot $(pwd)" \
    --define="glslang_ver 11.8.0" \
    --undefine=_disable_source_fetch \
    -ba ./rpm/wek.spec

sudo umount ~/rpmbuild/BUILD
```