### PR TITLE
Port crash fixes and install scripts from cycloarcane/stability-fixes-and-install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/backend_scene"]
 	path = src/backend_scene
-	url = https://github.com/CaptSilver/wallpaper-scene-renderer.git
+	url = https://github.com/RainyPixel/wallpaper-scene-renderer.git

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Wallpaper Engine KDE Plugin - One-shot installer
+# Detects distro, installs dependencies, builds and installs the plugin.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()      { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERR ]${NC} $*" >&2; }
+die()     { error "$*"; exit 1; }
+
+# ── check we're in the project root ──────────────────────────────────────────
+[[ -f CMakeLists.txt && -f plugin/metadata.json ]] \
+    || die "Run this script from the wallpaper-engine-kde-plugin project root."
+
+# ── detect distro ─────────────────────────────────────────────────────────────
+detect_distro() {
+    if [[ -f /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        echo "${ID:-unknown}"
+    else
+        echo "unknown"
+    fi
+}
+
+DISTRO=$(detect_distro)
+info "Detected distro: ${DISTRO}"
+
+# ── install dependencies ──────────────────────────────────────────────────────
+install_deps() {
+    case "${DISTRO}" in
+        arch|cachyos|endeavouros|manjaro)
+            info "Installing Arch-based dependencies…"
+            sudo pacman -S --needed --noconfirm \
+                extra-cmake-modules libplasma ninja base-devel cmake \
+                vulkan-headers lz4 mpv sndio \
+                qt6-declarative qt6-websockets qt6-webchannel \
+                gst-libav
+            ;;
+        debian|ubuntu|linuxmint|pop)
+            info "Installing Debian-based dependencies…"
+            sudo apt-get update -qq
+            sudo apt-get install -y \
+                build-essential cmake ninja-build \
+                libvulkan-dev liblz4-dev libmpv-dev \
+                gstreamer1.0-libav \
+                qt6-base-private-dev \
+                libqt6webchannel6-dev libqt6websockets6-dev \
+                plasma-workspace-dev extra-cmake-modules
+            ;;
+        fedora)
+            info "Installing Fedora dependencies…"
+            info "Note: RPM Fusion repository is required for mpv and gstreamer-libav."
+            sudo dnf install -y \
+                cmake ninja-build gcc-c++ \
+                vulkan-headers lz4-devel mpv-libs-devel \
+                gstreamer1-libav \
+                qt6-qtbase-private-devel libplasma-devel \
+                qt6-qtwebchannel-devel qt6-qtwebsockets-devel \
+                plasma-workspace-devel kf6-plasma-devel \
+                kf6-kcoreaddons-devel kf6-kpackage-devel \
+                extra-cmake-modules
+            ;;
+        opensuse*|suse)
+            info "Installing openSUSE dependencies…"
+            info "Note: Packman repository is required for full codec support."
+            sudo zypper install -y \
+                cmake ninja gcc-c++ \
+                vulkan-devel liblz4-devel mpv-devel \
+                gstreamer-plugins-libav \
+                qt6-base-private-devel \
+                qt6-websockets-devel \
+                plasma-framework-devel \
+                extra-cmake-modules
+            ;;
+        *)
+            warn "Unknown distro '${DISTRO}'. Skipping automatic dependency installation."
+            warn "Please install the required packages manually before continuing."
+            warn "See README.md for the package list for your distro."
+            read -rp "Continue anyway? [y/N] " ans
+            [[ "${ans,,}" == "y" ]] || exit 0
+            ;;
+    esac
+    ok "Dependencies installed."
+}
+
+# ── init git submodules ───────────────────────────────────────────────────────
+init_submodules() {
+    info "Initialising git submodules (scene renderer)…"
+    git submodule update --init --force --recursive \
+        || die "Failed to initialise submodules. Check your internet connection."
+    ok "Submodules ready."
+}
+
+# ── build ─────────────────────────────────────────────────────────────────────
+build_plugin() {
+    info "Configuring build…"
+    cmake -B build -S . -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        || die "CMake configuration failed. Check the output above for missing dependencies."
+
+    info "Building plugin…"
+    local jobs
+    jobs=$(nproc 2>/dev/null || echo 4)
+    cmake --build build --parallel "${jobs}" \
+        || die "Build failed. Check the output above for errors."
+    ok "Build complete."
+}
+
+# ── install ───────────────────────────────────────────────────────────────────
+install_plugin() {
+    info "Installing plugin (may need sudo)…"
+    sudo cmake --install build \
+        || die "Install failed."
+    ok "Plugin installed successfully."
+}
+
+# ── restart plasmashell ───────────────────────────────────────────────────────
+restart_plasma() {
+    info "Restarting plasmashell to load the new plugin…"
+    if systemctl --user is-active plasma-plasmashell.service &>/dev/null; then
+        systemctl --user restart plasma-plasmashell.service \
+            && ok "plasmashell restarted." \
+            || warn "Could not restart plasmashell automatically. Please log out and back in."
+    else
+        warn "plasma-plasmashell service not found. Please restart your KDE session manually."
+    fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Wallpaper Engine KDE Plugin – Installer"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Parse flags
+SKIP_DEPS=0
+SKIP_RESTART=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-deps)    SKIP_DEPS=1 ;;
+        --skip-restart) SKIP_RESTART=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--skip-deps] [--skip-restart]"
+            echo ""
+            echo "  --skip-deps     Skip dependency installation"
+            echo "  --skip-restart  Skip restarting plasmashell after install"
+            exit 0
+            ;;
+    esac
+done
+
+[[ "${SKIP_DEPS}" == "1" ]] || install_deps
+init_submodules
+build_plugin
+install_plugin
+[[ "${SKIP_RESTART}" == "1" ]] || restart_plasma
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Installation complete!"
+echo ""
+echo "  Next steps:"
+echo "  1. Right-click your desktop → Configure Desktop and Wallpaper"
+echo "  2. Select 'Wallpaper Engine for KDE' from the wallpaper type list"
+echo "  3. Point the plugin at your Steam library folder"
+echo "     (usually ~/.local/share/Steam)"
+echo ""
+echo "  If the plugin does not appear, restart your KDE session."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/src/TTYSwitchMonitor.cpp
+++ b/src/TTYSwitchMonitor.cpp
@@ -6,7 +6,8 @@ using namespace wekde;
 TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem* parent): QQuickItem(parent), m_sleeping(false) {
     QDBusConnection systemBus = QDBusConnection::systemBus();
     if (! systemBus.isConnected()) {
-        qFatal("Cannot connect to the D-Bus system bus");
+        qWarning() << "TTYSwitchMonitor: Cannot connect to the D-Bus system bus."
+                   << "Sleep/wake detection will be disabled.";
         return;
     }
 
@@ -18,7 +19,8 @@ TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem* parent): QQuickItem(parent), m_sl
                                        SLOT(handlePrepareForSleep(bool)));
 
     if (! connected) {
-        qFatal("Failed to connect to PrepareForSleep signal");
+        qWarning() << "TTYSwitchMonitor: Failed to connect to PrepareForSleep signal."
+                   << "Sleep/wake detection will be disabled.";
     }
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Wallpaper Engine KDE Plugin - Uninstaller
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()    { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERR ]${NC} $*" >&2; }
+die()   { error "$*"; exit 1; }
+
+PLUGIN_ID="com.github.catsout.wallpaperEngineKde"
+QML_SYSTEM_DIR="/usr/lib/qt6/qml/com/github/catsout/wallpaperEngineKde"
+PLASMA_USER_DIR="${HOME}/.local/share/plasma/wallpapers/${PLUGIN_ID}"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Wallpaper Engine KDE Plugin – Uninstaller"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Parse flags
+SKIP_RESTART=0
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-restart) SKIP_RESTART=1 ;;
+        --yes|-y)       YES=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--yes] [--skip-restart]"
+            echo ""
+            echo "  --yes / -y      Skip confirmation prompt"
+            echo "  --skip-restart  Skip restarting plasmashell after uninstall"
+            exit 0
+            ;;
+    esac
+done
+
+# ── confirm ───────────────────────────────────────────────────────────────────
+if [[ "${YES}" == "0" ]]; then
+    echo "This will remove:"
+    echo "  [system]  ${QML_SYSTEM_DIR}"
+    echo "  [user]    ${PLASMA_USER_DIR}"
+    echo ""
+    read -rp "Proceed? [y/N] " ans
+    [[ "${ans,,}" == "y" ]] || { info "Aborted."; exit 0; }
+    echo ""
+fi
+
+# ── remove system QML plugin (requires sudo) ──────────────────────────────────
+remove_system() {
+    if [[ -d "${QML_SYSTEM_DIR}" ]]; then
+        info "Removing system QML plugin: ${QML_SYSTEM_DIR}"
+        sudo rm -rf "${QML_SYSTEM_DIR}" \
+            && ok "Removed ${QML_SYSTEM_DIR}" \
+            || { error "Failed to remove ${QML_SYSTEM_DIR}"; return 1; }
+    else
+        warn "System QML plugin not found (already uninstalled?)"
+    fi
+}
+
+# ── remove plasma user package ────────────────────────────────────────────────
+remove_user_pkg() {
+    if [[ -d "${PLASMA_USER_DIR}" ]]; then
+        info "Removing user plasma package: ${PLASMA_USER_DIR}"
+        if command -v kpackagetool6 &>/dev/null; then
+            kpackagetool6 -t Plasma/Wallpaper -r "${PLUGIN_ID}" 2>/dev/null \
+                && ok "Removed via kpackagetool6" \
+                || { warn "kpackagetool6 removal failed, falling back to rm"; rm -rf "${PLASMA_USER_DIR}"; ok "Removed ${PLASMA_USER_DIR}"; }
+        else
+            rm -rf "${PLASMA_USER_DIR}"
+            ok "Removed ${PLASMA_USER_DIR}"
+        fi
+    else
+        warn "User plasma package not found (already uninstalled?)"
+    fi
+}
+
+# ── restart plasmashell ───────────────────────────────────────────────────────
+restart_plasma() {
+    info "Restarting plasmashell…"
+    if systemctl --user is-active plasma-plasmashell.service &>/dev/null; then
+        systemctl --user restart plasma-plasmashell.service \
+            && ok "plasmashell restarted." \
+            || warn "Could not restart plasmashell. Please log out and back in."
+    else
+        warn "plasma-plasmashell service not active. Please restart your KDE session."
+    fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+remove_system
+remove_user_pkg
+
+[[ "${SKIP_RESTART}" == "0" ]] && restart_plasma
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Uninstall complete."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Ports the fixes from [cycloarcane/wallpaper-engine-kde-plugin PR #573](https://github.com/catsout/wallpaper-engine-kde-plugin/pull/573) upstream.

## Changes

### Fix 1 — TTYSwitchMonitor: qFatal → qWarning
On systems where D-Bus is unavailable or slow at startup, the two `qFatal()` calls in `TTYSwitchMonitor` would call `abort()` and kill plasmashell immediately. Replaced with `qWarning()` so the plugin degrades gracefully with sleep/wake detection disabled.

### Fix 3 & 4 — install.sh / uninstall.sh
New one-shot install and uninstall scripts supporting Arch, Debian/Ubuntu, Fedora, and openSUSE. The Arch dependency list includes `sndio`, which is required by `libmpv` on Arch (without it the plugin fails to load with a missing-library error in the journal).

### Submodule cleanup
Repoints `.gitmodules` back to `RainyPixel/wallpaper-scene-renderer` (removes the dependency on the third-party `CaptSilver` fork).

## Pending

### Fix 2 — Particle wallpaper crash
A separate PR has been opened against your scene renderer:
👉 https://github.com/RainyPixel/wallpaper-scene-renderer/pull/1

Certain particle wallpapers (e.g. workshop item 2609314607) cause a `std::out_of_range` exception in `SpriteAnimation::GetCurFrame` which propagates uncaught through `LoadMaterial` and hits `std::terminate`. Once that renderer PR is merged the submodule pointer here can be bumped to include it.

### Fix 5 — NO TEXT badge
The original Python backend had a `analyse_pkg` function that detected text objects in `.pkg` files and showed a warning badge in the wallpaper picker. Since this fork replaced Python with native C++, this needs reimplementing as a `FileHelper::analysePkg()` method. Will follow up in a separate PR.

## Test plan
- [ ] Build on Arch — `./install.sh --skip-restart` completes without errors
- [ ] Confirm `sndio` is pulled in and plugin loads (`journalctl /usr/bin/plasmashell` shows no missing-library errors)
- [ ] Disconnect D-Bus / run on a system without login1 — plasmashell stays alive, warning appears in journal
- [ ] `./uninstall.sh --yes` removes the plugin cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)