### PR TITLE
Add pause on gamemoderun support

### DIFF
--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -42,6 +42,10 @@
       <label>Pause Battery Percent</label>
       <default>0</default>
     </entry>
+    <entry name="PauseOnGamemode" type="Bool">
+      <label>Pause when gamemode is enabled</label>
+      <default>false</default>
+    </entry>
     <entry name="SortMode" type="Int">
       <label>Sort mode</label>
       <default>0</default>

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -38,6 +38,7 @@ ColumnLayout {
     property alias  cfg_PauseFilterByScreen: settingPage.cfg_PauseFilterByScreen
     property alias  cfg_PauseOnBatPower:     settingPage.cfg_PauseOnBatPower
     property alias  cfg_PauseBatPercent:     settingPage.cfg_PauseBatPercent
+    property alias  cfg_PauseOnGamemode:     settingPage.cfg_PauseOnGamemode
     property int    cfg_DisplayMode
     property int    cfg_PauseMode
     property int    cfg_VideoBackend

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -87,7 +87,7 @@ Rectangle {
     }
 
     // auto pause
-    property bool   ok: !windowModel.reqPause && !powerSource.reqPause
+    property bool   ok: !windowModel.reqPause && !powerSource.reqPause && !(gamemodeLoader.item ? gamemodeLoader.item.reqPause : false)
 
     // detect TTY switch and pause wallpaper(s)
     TTYSwitchMonitor {
@@ -100,6 +100,15 @@ Rectangle {
                 console.log("Waking up (VT switch back)");
                 this.play();
             }
+        }
+    }
+
+    Loader {
+        id: gamemodeLoader
+        active: background.pauseOnGamemode
+
+        sourceComponent: Component {
+            GamemodeMonitor {}
         }
     }
 

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -33,6 +33,8 @@ Flickable {
     property alias cfg_PauseOnBatPower: chkbox_pauseOnBatPower.checked
     property alias cfg_PauseBatPercent: spin_pauseBatPercent.value
 
+    property alias cfg_PauseOnGamemode: chkbox_pauseOnGameMode.checked
+
 
     Layout.fillWidth: true
     ScrollBar.vertical: ScrollBar { id: scrollbar }
@@ -122,6 +124,13 @@ Flickable {
                         from: 0
                         to: 100
                         stepSize: 1
+                }
+            }
+            OptionItem {
+                text: 'Pause if gamemode is started'
+                text_color: Kirigami.Theme.textColor
+                actor: Switch {
+                    id: chkbox_pauseOnGameMode
                 }
             }
             OptionItem {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(${PROJECT_NAME}
 	TTYSwitchMonitor.cpp
 	PluginInfo.cpp
 	FileHelper.cpp
+	GamemodeMonitor.cpp
 	qmldir
 )
 

--- a/src/GamemodeMonitor.cpp
+++ b/src/GamemodeMonitor.cpp
@@ -6,7 +6,7 @@ using namespace wekde;
 GamemodeMonitor::GamemodeMonitor(QQuickItem* parent): QQuickItem(parent), m_reqPause(false) {
     QDBusConnection sessionBus = QDBusConnection::sessionBus();
     if (! sessionBus.isConnected()) {
-        qFatal("gamemode: Cannot connect to the D-Bus session bus");
+        qWarning("gamemode: Cannot connect to the D-Bus session bus");
         return;
     }
 

--- a/src/GamemodeMonitor.cpp
+++ b/src/GamemodeMonitor.cpp
@@ -1,0 +1,60 @@
+#include "GamemodeMonitor.hpp"
+#include <QDebug>
+
+using namespace wekde;
+
+GamemodeMonitor::GamemodeMonitor(QQuickItem* parent): QQuickItem(parent), m_reqPause(false) {
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    if (! sessionBus.isConnected()) {
+        qFatal("gamemode: Cannot connect to the D-Bus session bus");
+        return;
+    }
+
+    bool connected =
+        sessionBus.connect("com.feralinteractive.GameMode",
+                           "/com/feralinteractive/GameMode",
+                           "org.freedesktop.DBus.Properties",
+                           "PropertiesChanged",
+                           this,
+                           SLOT(handlePropsChanged(QString, QVariantMap, QStringList)));
+
+    if (! connected) {
+        qDebug("gamemode: Failed to connect to PropertiesChanged signal");
+        return;
+    }
+
+    QDBusMessage msg = QDBusMessage::createMethodCall("com.feralinteractive.GameMode",
+                                                      "/com/feralinteractive/GameMode",
+                                                      "org.freedesktop.DBus.Properties",
+                                                      "Get");
+    msg << "com.feralinteractive.GameMode" << "ClientCount";
+
+    QDBusPendingCall         currentClientCall = sessionBus.asyncCall(msg);
+    QDBusPendingCallWatcher* watcher = new QDBusPendingCallWatcher(currentClientCall, this);
+
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher]() {
+        QDBusPendingReply<QVariant> reply = *watcher;
+
+        if (reply.isValid()) {
+            int  clientCount = reply.value().toInt();
+            bool newPlaying  = clientCount > 0;
+
+            if (newPlaying != m_reqPause) {
+                m_reqPause = newPlaying;
+                emit reqPauseChanged();
+            }
+        }
+
+        watcher->deleteLater();
+    });
+}
+
+void GamemodeMonitor::handlePropsChanged(const QString&, const QVariantMap& map,
+                                         const QStringList&) {
+    bool newPause = map.value("ClientCount").toInt() > 0;
+
+    if (newPause != m_reqPause) {
+        m_reqPause = newPause;
+        emit reqPauseChanged();
+    }
+}

--- a/src/GamemodeMonitor.hpp
+++ b/src/GamemodeMonitor.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <QQuickItem>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+
+namespace wekde
+{
+
+class GamemodeMonitor : public QQuickItem {
+    Q_OBJECT
+    Q_PROPERTY(bool reqPause READ reqPause NOTIFY reqPauseChanged)
+
+public:
+    GamemodeMonitor(QQuickItem* parent = nullptr);
+
+    bool reqPause() const { return m_reqPause; }
+
+signals:
+    void reqPauseChanged();
+
+public slots:
+    void handlePropsChanged(const QString& name, const QVariantMap& map, const QStringList& list);
+
+private:
+    bool m_reqPause;
+};
+
+} // namespace wekde

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -7,6 +7,7 @@
 #include "TTYSwitchMonitor.hpp"
 #include "PluginInfo.hpp"
 #include "FileHelper.hpp"
+#include "GamemodeMonitor.hpp"
 
 constexpr std::array<uint, 2> WPVer { 1, 2 };
 
@@ -24,6 +25,7 @@ public:
         qmlRegisterType<mpv::MpvObject>(uri, WPVer[0], WPVer[1], "Mpv");
         qmlRegisterType<wekde::TTYSwitchMonitor>(uri, WPVer[0], WPVer[1], "TTYSwitchMonitor");
         qmlRegisterType<wekde::FileHelper>(uri, WPVer[0], WPVer[1], "FileHelper");
+        qmlRegisterType<wekde::GamemodeMonitor>(uri, WPVer[0], WPVer[1], "GamemodeMonitor");
     }
 };
 


### PR DESCRIPTION
This PR adds a support for pausing a wallpaper when gamemode is having clients (some process which started via gamemoderun, e.g. some game).
It would be nice to have because some wallpapers may load GPU and decrease FPS in games.