### PR TITLE
fix null deref in WPMdlParser::Parse when mdl file is missing

### DIFF
--- a/src/backend_scene/src/WPMdlParser.cpp
+++ b/src/backend_scene/src/WPMdlParser.cpp
@@ -42,8 +42,8 @@ constexpr uint32_t singile_bone_frame = 4 * 9;
 bool WPMdlParser::Parse(std::string_view path, fs::VFS& vfs, WPMdl& mdl) {
     auto str_path = std::string(path);
     auto pfile    = vfs.Open("/assets/" + str_path);
-    auto memfile  = fs::MemBinaryStream(*pfile);
     if (! pfile) return false;
+    auto memfile  = fs::MemBinaryStream(*pfile);
     auto& f = memfile;
 
     mdl.mdlv = ReadMDLVesion(f);


### PR DESCRIPTION
`pfile` gets dereferenced to construct `memfile` before the null check on the next line. if the .mdl file doesn't exist (removed wallpaper, moved steam library, etc), this segfaults and takes plasmashell down with it.

just swapped the two lines so we bail out before touching the pointer.

```diff
-    auto memfile  = fs::MemBinaryStream(*pfile);
     if (! pfile) return false;
+    auto memfile  = fs::MemBinaryStream(*pfile);
```