### PR TITLE
Global Mode, scene background fix, and multi-monitor VRAM/perf work

### DIFF
--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -70,6 +70,10 @@
       <label>Prevent randomization while wallpapers are paused</label>
       <default>false</default>
     </entry>
+    <entry name="GlobalMode" type="Bool">
+      <label>Share one configuration across all screens</label>
+      <default>false</default>
+    </entry>
     <entry name="MpvStats" type="Bool">
       <label>Mpv Stats</label>
       <default>false</default>

--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -78,6 +78,10 @@
       <label>Cache static layers of scene wallpapers</label>
       <default>true</default>
     </entry>
+    <entry name="ShareGpuContext" type="Bool">
+      <label>Share one GPU device across screens on the same GPU</label>
+      <default>true</default>
+    </entry>
     <entry name="MpvStats" type="Bool">
       <label>Mpv Stats</label>
       <default>false</default>

--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -74,6 +74,10 @@
       <label>Share one configuration across all screens</label>
       <default>false</default>
     </entry>
+    <entry name="SceneCachePasses" type="Bool">
+      <label>Cache static layers of scene wallpapers</label>
+      <default>true</default>
+    </entry>
     <entry name="MpvStats" type="Bool">
       <label>Mpv Stats</label>
       <default>false</default>

--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -82,6 +82,10 @@
       <label>Share one GPU device across screens on the same GPU</label>
       <default>true</default>
     </entry>
+    <entry name="MirrorScene" type="Bool">
+      <label>Render an identical scene wallpaper once and mirror it to other screens</label>
+      <default>false</default>
+    </entry>
     <entry name="MpvStats" type="Bool">
       <label>Mpv Stats</label>
       <default>false</default>

--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -43,6 +43,7 @@ Item{
         anchors.fill: parent
         fps: background.fps
         muted: background.mute
+        cachePasses: background.cacheScenePasses
         speed: background.speed
         assets: sceneItem.assets
         userProperties: sceneItem.userPropsJson

--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -44,6 +44,7 @@ Item{
         fps: background.fps
         muted: background.mute
         cachePasses: background.cacheScenePasses
+        shareGpu: background.shareGpuContext
         speed: background.speed
         assets: sceneItem.assets
         userProperties: sceneItem.userPropsJson

--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -45,6 +45,7 @@ Item{
         muted: background.mute
         cachePasses: background.cacheScenePasses
         shareGpu: background.shareGpuContext
+        mirrorScene: background.mirrorScene
         speed: background.speed
         assets: sceneItem.assets
         userProperties: sceneItem.userPropsJson

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -31,6 +31,7 @@ ColumnLayout {
     property alias  cfg_MpvStats:            settingPage.cfg_MpvStats
     property alias  cfg_SceneCachePasses:    settingPage.cfg_SceneCachePasses
     property alias  cfg_ShareGpuContext:     settingPage.cfg_ShareGpuContext
+    property alias  cfg_MirrorScene:         settingPage.cfg_MirrorScene
     property alias  cfg_Speed:               settingPage.cfg_Speed
     property alias  cfg_MuteAudio:           settingPage.cfg_MuteAudio
     property alias  cfg_MouseInput:          settingPage.cfg_MouseInput

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -29,6 +29,7 @@ ColumnLayout {
     property alias  cfg_Fps:                 settingPage.cfg_Fps
     property alias  cfg_Volume:              settingPage.cfg_Volume
     property alias  cfg_MpvStats:            settingPage.cfg_MpvStats
+    property alias  cfg_SceneCachePasses:    settingPage.cfg_SceneCachePasses
     property alias  cfg_Speed:               settingPage.cfg_Speed
     property alias  cfg_MuteAudio:           settingPage.cfg_MuteAudio
     property alias  cfg_MouseInput:          settingPage.cfg_MouseInput

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.5
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents
 import org.kde.kirigami 2.4 as Kirigami
+import com.github.catsout.wallpaperEngineKde
 
 import "page"
 
@@ -35,6 +36,7 @@ ColumnLayout {
     property alias  cfg_SwitchTimer:         settingPage.cfg_SwitchTimer
     property alias  cfg_RandomizeWallpaper:  settingPage.cfg_RandomizeWallpaper
     property alias  cfg_NoRandomWhilePaused: settingPage.cfg_NoRandomWhilePaused
+    property alias  cfg_GlobalMode:          settingPage.cfg_GlobalMode
     property alias  cfg_PauseFilterByScreen: settingPage.cfg_PauseFilterByScreen
     property alias  cfg_PauseOnBatPower:     settingPage.cfg_PauseOnBatPower
     property alias  cfg_PauseBatPercent:     settingPage.cfg_PauseBatPercent
@@ -104,8 +106,29 @@ ColumnLayout {
         `, this);
     }
 
+    // Global Mode: on Apply, push the shared keys into ~/.config/wekde/global.json
+    // and wake the running wallpaper(s) (the config dialog may be another process).
+    GlobalConfig {
+        id: globalCfg
+    }
+    WallpaperSyncBus {
+        id: syncBus
+    }
     function saveConfig() {
         wallpaperPage.saveConfig();
+        globalCfg.enabled = cfg_GlobalMode;
+        if(cfg_GlobalMode) {
+            globalCfg.setBatch({
+                "WallpaperSource":     cfg_WallpaperSource,
+                "WallpaperWorkShopId": cfg_WallpaperWorkShopId,
+                "RandomizeWallpaper":  cfg_RandomizeWallpaper,
+                "SwitchTimer":         cfg_SwitchTimer,
+                "NoRandomWhilePaused": cfg_NoRandomWhilePaused,
+                "FilterStr":           cfg_FilterStr,
+                "SortMode":            cfg_SortMode
+            });
+        }
+        syncBus.broadcastGlobalChanged();
     }
 
     WallpaperListModel {

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -117,19 +117,36 @@ ColumnLayout {
     WallpaperSyncBus {
         id: syncBus
     }
+    // Wallpaper selection as it was when the dialog opened; used so that pressing
+    // Apply for an unrelated setting in Global Mode doesn't push this screen's
+    // (possibly stale) per-screen wallpaper back into the shared global config.
+    property string initialWallpaperSource
+    property string initialWallpaperWorkShopId
+    Component.onCompleted: {
+        initialWallpaperSource = cfg_WallpaperSource;
+        initialWallpaperWorkShopId = cfg_WallpaperWorkShopId;
+    }
+
     function saveConfig() {
         wallpaperPage.saveConfig();
         globalCfg.enabled = cfg_GlobalMode;
         if(cfg_GlobalMode) {
-            globalCfg.setBatch({
-                "WallpaperSource":     cfg_WallpaperSource,
-                "WallpaperWorkShopId": cfg_WallpaperWorkShopId,
+            const batch = {
                 "RandomizeWallpaper":  cfg_RandomizeWallpaper,
                 "SwitchTimer":         cfg_SwitchTimer,
                 "NoRandomWhilePaused": cfg_NoRandomWhilePaused,
                 "FilterStr":           cfg_FilterStr,
                 "SortMode":            cfg_SortMode
-            });
+            };
+            // Only sync the wallpaper itself if the user actually changed the
+            // selection this session, so we never overwrite the shared wallpaper
+            // with a stale per-screen value.
+            if(cfg_WallpaperSource !== initialWallpaperSource
+                || cfg_WallpaperWorkShopId !== initialWallpaperWorkShopId) {
+                batch["WallpaperSource"] = cfg_WallpaperSource;
+                batch["WallpaperWorkShopId"] = cfg_WallpaperWorkShopId;
+            }
+            globalCfg.setBatch(batch);
         }
         syncBus.broadcastGlobalChanged();
     }

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -30,6 +30,7 @@ ColumnLayout {
     property alias  cfg_Volume:              settingPage.cfg_Volume
     property alias  cfg_MpvStats:            settingPage.cfg_MpvStats
     property alias  cfg_SceneCachePasses:    settingPage.cfg_SceneCachePasses
+    property alias  cfg_ShareGpuContext:     settingPage.cfg_ShareGpuContext
     property alias  cfg_Speed:               settingPage.cfg_Speed
     property alias  cfg_MuteAudio:           settingPage.cfg_MuteAudio
     property alias  cfg_MouseInput:          settingPage.cfg_MouseInput

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -27,6 +27,7 @@ Rectangle {
     property int    videoBackend: wallpaper.configuration.VideoBackend
     property int    switchTimer: effCfg("SwitchTimer", wallpaper.configuration.SwitchTimer)
     property int    fps: wallpaper.configuration.Fps
+    property bool   cacheScenePasses: wallpaper.configuration.SceneCachePasses
 
     property bool   randomizeWallpaper: effCfg("RandomizeWallpaper", wallpaper.configuration.RandomizeWallpaper)
     property bool   noRandomWhilePaused: effCfg("NoRandomWhilePaused", wallpaper.configuration.NoRandomWhilePaused)

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -28,6 +28,7 @@ Rectangle {
     property int    switchTimer: effCfg("SwitchTimer", wallpaper.configuration.SwitchTimer)
     property int    fps: wallpaper.configuration.Fps
     property bool   cacheScenePasses: wallpaper.configuration.SceneCachePasses
+    property bool   shareGpuContext: wallpaper.configuration.ShareGpuContext
 
     property bool   randomizeWallpaper: effCfg("RandomizeWallpaper", wallpaper.configuration.RandomizeWallpaper)
     property bool   noRandomWhilePaused: effCfg("NoRandomWhilePaused", wallpaper.configuration.NoRandomWhilePaused)

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -29,6 +29,7 @@ Rectangle {
     property int    fps: wallpaper.configuration.Fps
     property bool   cacheScenePasses: wallpaper.configuration.SceneCachePasses
     property bool   shareGpuContext: wallpaper.configuration.ShareGpuContext
+    property bool   mirrorScene: wallpaper.configuration.MirrorScene
 
     property bool   randomizeWallpaper: effCfg("RandomizeWallpaper", wallpaper.configuration.RandomizeWallpaper)
     property bool   noRandomWhilePaused: effCfg("NoRandomWhilePaused", wallpaper.configuration.NoRandomWhilePaused)

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -11,16 +11,25 @@ Rectangle {
     color: wallpaper.configuration.BackgroundColor
     
     property string steamlibrary: Qt.resolvedUrl(wallpaper.configuration.SteamLibraryPath).toString()
-    property string source: Qt.resolvedUrl(wallpaper.configuration.WallpaperSource).toString()
+    // Global Mode: shared config (wallpaper choice + randomization) lives in
+    // ~/.config/wekde/global.json instead of per-screen KConfig. globalRev is
+    // bumped on every global change to re-evaluate the resolver bindings below.
+    property int    globalRev: 0
+    function effCfg(key, fallback) {
+        background.globalRev;
+        return globalCfg.enabled ? globalCfg.get(key, fallback) : fallback;
+    }
 
-    property string filterStr: wallpaper.configuration.FilterStr
+    property string source: Qt.resolvedUrl(effCfg("WallpaperSource", wallpaper.configuration.WallpaperSource)).toString()
+
+    property string filterStr: effCfg("FilterStr", wallpaper.configuration.FilterStr)
 
     property int    videoBackend: wallpaper.configuration.VideoBackend
-    property int    switchTimer: wallpaper.configuration.SwitchTimer
+    property int    switchTimer: effCfg("SwitchTimer", wallpaper.configuration.SwitchTimer)
     property int    fps: wallpaper.configuration.Fps
 
-    property bool   randomizeWallpaper: wallpaper.configuration.RandomizeWallpaper
-    property bool   noRandomWhilePaused: wallpaper.configuration.NoRandomWhilePaused
+    property bool   randomizeWallpaper: effCfg("RandomizeWallpaper", wallpaper.configuration.RandomizeWallpaper)
+    property bool   noRandomWhilePaused: effCfg("NoRandomWhilePaused", wallpaper.configuration.NoRandomWhilePaused)
     property bool   mouseInput: wallpaper.configuration.MouseInput
     property bool   mpvStats: wallpaper.configuration.MpvStats
     property string mpvHwdec: wallpaper.configuration.MpvHwdec
@@ -31,7 +40,7 @@ Rectangle {
     
     property var curOpt: ({})
     property string workshopid: {
-        const wid = wallpaper.configuration.WallpaperWorkShopId;
+        const wid = effCfg("WallpaperWorkShopId", wallpaper.configuration.WallpaperWorkShopId);
         pyext.read_wallpaper_config(wid).then((res) => this.curOpt = res);
         return wid;
     }
@@ -247,12 +256,30 @@ Rectangle {
         }
         readfile: pyext.readfile
 
+        function applyWallpaperBySource(source, workshopid) {
+            wallpaper.configuration.WallpaperWorkShopId = workshopid;
+            wallpaper.configuration.WallpaperSource = source;
+        }
         function changeWallpaper(index) {
             if(this.model.count === 0) return;
             const model = this.model.get(index);
-            wallpaper.configuration.WallpaperWorkShopId = model.workshopid;
-            wallpaper.configuration.WallpaperSource = Common.packWallpaperSource(model);
+            this.applyWallpaperBySource(Common.packWallpaperSource(model), model.workshopid);
         }
+    }
+
+    GlobalConfig {
+        id: globalCfg
+    }
+    Connections {
+        target: globalCfg
+        function onChanged(key, value) { background.globalRev++; }
+        function onEnabledChanged()    { background.globalRev++; }
+    }
+    // wakes this renderer when the config dialog (possibly another process)
+    // writes the global config
+    WallpaperSyncBus {
+        id: syncBus
+        onGlobalConfigChanged: globalCfg.reload()
     }
     Timer {
         id: randomizeTimer
@@ -260,10 +287,19 @@ Rectangle {
         interval: background.switchTimer * 1000 * 60
         repeat: true
         onTriggered: {
-            if(!(background.noRandomWhilePaused && !background.ok)) {
-                const i = Math.round(Math.random() * wpListModel.model.count);
-                wpListModel.changeWallpaper(i);
-            }
+            if(background.noRandomWhilePaused && !background.ok) return;
+            // in Global Mode only the primary screen picks; the choice is
+            // shared via the global config so all screens apply the same one
+            if(globalCfg.enabled && !syncBus.isPrimary) return;
+            if(wpListModel.model.count === 0) return;
+
+            const i = Math.floor(Math.random() * wpListModel.model.count);
+            const model = wpListModel.model.get(i);
+            const source = Common.packWallpaperSource(model);
+            if(globalCfg.enabled)
+                globalCfg.setBatch({ "WallpaperSource": source, "WallpaperWorkShopId": model.workshopid });
+            else
+                wpListModel.applyWallpaperBySource(source, model.workshopid);
         }
     }
 

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -27,6 +27,7 @@ Flickable {
     property alias cfg_MpvStats: ckbox_mpvStats.checked
     property alias cfg_SceneCachePasses: ckbox_cacheScenePasses.checked
     property alias cfg_ShareGpuContext: ckbox_shareGpuContext.checked
+    property alias cfg_MirrorScene: ckbox_mirrorScene.checked
     property string cfg_MpvHwdec
     property alias cfg_Speed: spin_speed.dValue
     property alias cfg_MuteAudio: ckbox_muteAudio.checked
@@ -457,6 +458,25 @@ Flickable {
                         color: Kirigami.Theme.disabledTextColor
                         text: "On multi-monitor setups, share one GPU device so identical "
                             + "textures load once instead of per screen. Saves VRAM. "
+                            + "Takes effect after the wallpaper reloads."
+                    }
+                }
+            }
+            OptionItem {
+                text: 'Mirror scene across screens'
+                text_color: Kirigami.Theme.textColor
+                icon: '../../images/tuning.svg'
+                actor: Switch {
+                    id: ckbox_mirrorScene
+                }
+                contentBottom: ColumnLayout {
+                    Text {
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                        color: Kirigami.Theme.disabledTextColor
+                        text: "On multi-monitor setups showing the same scene wallpaper, render "
+                            + "it once and mirror it to the other screens. Saves the per-screen "
+                            + "render-target VRAM. Skipped for wallpapers that react to the cursor. "
                             + "Takes effect after the wallpaper reloads."
                     }
                 }

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -133,9 +133,10 @@ Flickable {
                 }
             }
             OptionItem {
+                // Independent of "pause on battery power": the runtime applies this
+                // threshold on its own (0 = off), so keep it reachable to reset.
                 text: 'Pause if battery level is below'
                 text_color: Kirigami.Theme.textColor
-                visible: chkbox_pauseOnBatPower.checked
                 actor: RowLayout {
                     SpinBox {
                         id: spin_pauseBatPercent

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -25,6 +25,7 @@ Flickable {
     property alias cfg_Fps: sliderFps.value
     property alias cfg_Volume: sliderVol.value
     property alias cfg_MpvStats: ckbox_mpvStats.checked
+    property alias cfg_SceneCachePasses: ckbox_cacheScenePasses.checked
     property string cfg_MpvHwdec
     property alias cfg_Speed: spin_speed.dValue
     property alias cfg_MuteAudio: ckbox_muteAudio.checked
@@ -423,6 +424,23 @@ Flickable {
                     }
                 }
 
+            }
+            OptionItem {
+                text: 'Cache static layers'
+                text_color: Kirigami.Theme.textColor
+                icon: '../../images/tuning.svg'
+                actor: Switch {
+                    id: ckbox_cacheScenePasses
+                }
+                contentBottom: ColumnLayout {
+                    Text {
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                        color: Kirigami.Theme.disabledTextColor
+                        text: "Render unchanging layers (e.g. blurred backgrounds) once instead of "
+                            + "every frame. Saves CPU/GPU. Disable if a wallpaper looks wrong."
+                    }
+                }
             }
             OptionItem {
                 text: 'Shader cache'

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -26,6 +26,7 @@ Flickable {
     property alias cfg_Volume: sliderVol.value
     property alias cfg_MpvStats: ckbox_mpvStats.checked
     property alias cfg_SceneCachePasses: ckbox_cacheScenePasses.checked
+    property alias cfg_ShareGpuContext: ckbox_shareGpuContext.checked
     property string cfg_MpvHwdec
     property alias cfg_Speed: spin_speed.dValue
     property alias cfg_MuteAudio: ckbox_muteAudio.checked
@@ -439,6 +440,24 @@ Flickable {
                         color: Kirigami.Theme.disabledTextColor
                         text: "Render unchanging layers (e.g. blurred backgrounds) once instead of "
                             + "every frame. Saves CPU/GPU. Disable if a wallpaper looks wrong."
+                    }
+                }
+            }
+            OptionItem {
+                text: 'Share GPU across screens'
+                text_color: Kirigami.Theme.textColor
+                icon: '../../images/tuning.svg'
+                actor: Switch {
+                    id: ckbox_shareGpuContext
+                }
+                contentBottom: ColumnLayout {
+                    Text {
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                        color: Kirigami.Theme.disabledTextColor
+                        text: "On multi-monitor setups, share one GPU device so identical "
+                            + "textures load once instead of per screen. Saves VRAM. "
+                            + "Takes effect after the wallpaper reloads."
                     }
                 }
             }

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -10,12 +10,17 @@ import "../js/utils.mjs" as Utils
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents
 import org.kde.kirigami 2.6 as Kirigami
+import com.github.catsout.wallpaperEngineKde
 
 Flickable {
     id: settingTab
 
     // Наследуем тему от родителя
     Kirigami.Theme.inherit: true
+
+    GlobalConfig {
+        id: globalCfg
+    }
 
     property alias cfg_Fps: sliderFps.value
     property alias cfg_Volume: sliderVol.value
@@ -28,6 +33,7 @@ Flickable {
     property alias cfg_SwitchTimer: randomSpin.value
     property alias cfg_RandomizeWallpaper: ckbox_randomizeWallpaper.checked
     property alias cfg_NoRandomWhilePaused: ckbox_noRandomWhilePaused.checked
+    property alias cfg_GlobalMode: ckbox_globalMode.checked
     property alias cfg_PauseFilterByScreen: ckbox_pauseFilterByScreen.checked
 
     property alias cfg_PauseOnBatPower: chkbox_pauseOnBatPower.checked
@@ -102,10 +108,18 @@ Flickable {
                }
             }
             OptionItem {
-                text: 'Only check window on current screen'
+                text: 'Only react to windows on this screen'
                 text_color: Kirigami.Theme.textColor
                 actor: Switch {
                     id: ckbox_pauseFilterByScreen
+                }
+                contentBottom: ColumnLayout {
+                    Text {
+                        Layout.fillWidth: true
+                        color: Kirigami.Theme.disabledTextColor
+                        wrapMode: Text.Wrap
+                        text: "When pausing on focus/maximized windows, ignore windows on other screens"
+                    }
                 }
             }
             OptionItem {
@@ -118,11 +132,15 @@ Flickable {
             OptionItem {
                 text: 'Pause if battery level is below'
                 text_color: Kirigami.Theme.textColor
-                actor: SpinBox {
+                visible: chkbox_pauseOnBatPower.checked
+                actor: RowLayout {
+                    SpinBox {
                         id: spin_pauseBatPercent
                         from: 0
                         to: 100
                         stepSize: 1
+                    }
+                    Label { text: " %"; color: Kirigami.Theme.textColor }
                 }
             }
             OptionItem {
@@ -225,6 +243,24 @@ Flickable {
                             id: ckbox_noRandomWhilePaused
                         }
                     }
+                }
+            }
+
+            OptionItem {
+                text: 'Same wallpaper on all screens'
+                text_color: Kirigami.Theme.textColor
+                icon: '../../images/window.svg'
+                actor: Switch {
+                    id: ckbox_globalMode
+                    // reflect the real shared state, not this screen's stale copy
+                    Component.onCompleted: checked = globalCfg.enabled
+                }
+                contentBottom: Text {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    color: Kirigami.Theme.disabledTextColor
+                    text: "Share the wallpaper choice and randomization across all screens "
+                        + "(one configuration for the whole system). Press Apply to take effect."
                 }
             }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(${PROJECT_NAME}
 	PluginInfo.cpp
 	FileHelper.cpp
 	GamemodeMonitor.cpp
+	WallpaperSyncBus.cpp
+	GlobalConfigStore.cpp
 	qmldir
 )
 

--- a/src/GlobalConfigStore.cpp
+++ b/src/GlobalConfigStore.cpp
@@ -1,0 +1,141 @@
+#include "GlobalConfigStore.hpp"
+
+#include <QStandardPaths>
+#include <QDir>
+#include <QFile>
+#include <QSaveFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QGlobalStatic>
+#include <QDebug>
+
+using namespace wekde;
+
+namespace
+{
+constexpr auto k_enabled_key = "enabled";
+}
+
+Q_GLOBAL_STATIC(GlobalConfigBackend, g_backend)
+
+GlobalConfigBackend* GlobalConfigBackend::instance() { return g_backend; }
+
+GlobalConfigBackend::GlobalConfigBackend() { load(); }
+
+QString GlobalConfigBackend::filePath() const {
+    QString dir =
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/wekde";
+    QDir().mkpath(dir);
+    return dir + "/global.json";
+}
+
+void GlobalConfigBackend::load() {
+    QFile f(filePath());
+    if (! f.open(QIODevice::ReadOnly)) return;
+    auto         doc = QJsonDocument::fromJson(f.readAll());
+    QWriteLocker locker(&m_lock);
+    if (doc.isObject()) m_data = doc.object().toVariantMap();
+}
+
+void GlobalConfigBackend::persist() const {
+    QSaveFile f(filePath());
+    if (! f.open(QIODevice::WriteOnly)) {
+        qWarning() << "GlobalConfigBackend: cannot write" << filePath();
+        return;
+    }
+    QJsonDocument doc(QJsonObject::fromVariantMap(m_data));
+    f.write(doc.toJson(QJsonDocument::Indented));
+    f.commit();
+}
+
+QStringList GlobalConfigBackend::apply(const QVariantMap& patch) {
+    QStringList changedKeys;
+    for (auto it = patch.constBegin(); it != patch.constEnd(); ++it) {
+        if (m_data.value(it.key()) != it.value()) {
+            m_data.insert(it.key(), it.value());
+            changedKeys << it.key();
+        }
+    }
+    return changedKeys;
+}
+
+QVariant GlobalConfigBackend::value(const QString& key, const QVariant& def) const {
+    QReadLocker locker(&m_lock);
+    return m_data.value(key, def);
+}
+
+bool GlobalConfigBackend::enabled() const { return value(k_enabled_key, false).toBool(); }
+
+QVariantMap GlobalConfigBackend::all() const {
+    QReadLocker locker(&m_lock);
+    return m_data;
+}
+
+void GlobalConfigBackend::setValue(const QString& key, const QVariant& val) {
+    setValues({ { key, val } });
+}
+
+void GlobalConfigBackend::setValues(const QVariantMap& patch) {
+    QStringList changedKeys;
+    {
+        QWriteLocker locker(&m_lock);
+        changedKeys = apply(patch);
+        if (changedKeys.isEmpty()) return;
+        persist();
+    }
+    for (const auto& key : changedKeys) emit changed(key, value(key));
+    if (changedKeys.contains(k_enabled_key)) emit enabledChanged();
+}
+
+void GlobalConfigBackend::reloadFromDisk() {
+    QVariantMap fresh;
+    {
+        QFile f(filePath());
+        if (f.open(QIODevice::ReadOnly)) {
+            auto doc = QJsonDocument::fromJson(f.readAll());
+            if (doc.isObject()) fresh = doc.object().toVariantMap();
+        }
+    }
+    QStringList changedKeys;
+    {
+        QWriteLocker locker(&m_lock);
+        // keys removed on disk
+        for (auto it = m_data.constBegin(); it != m_data.constEnd(); ++it)
+            if (! fresh.contains(it.key())) changedKeys << it.key();
+        // added/modified keys
+        for (auto it = fresh.constBegin(); it != fresh.constEnd(); ++it)
+            if (m_data.value(it.key()) != it.value()) changedKeys << it.key();
+        if (changedKeys.isEmpty()) return;
+        m_data = fresh;
+    }
+    for (const auto& key : changedKeys) emit changed(key, value(key));
+    if (changedKeys.contains(k_enabled_key)) emit enabledChanged();
+}
+
+// --- QML proxy ---
+
+GlobalConfig::GlobalConfig(QObject* parent): QObject(parent) {
+    auto* backend = GlobalConfigBackend::instance();
+    connect(backend, &GlobalConfigBackend::changed, this, &GlobalConfig::changed);
+    connect(backend, &GlobalConfigBackend::enabledChanged, this, &GlobalConfig::enabledChanged);
+}
+
+bool GlobalConfig::enabled() const { return GlobalConfigBackend::instance()->enabled(); }
+
+void GlobalConfig::setEnabled(bool on) { GlobalConfigBackend::instance()->setValue("enabled", on); }
+
+QVariant GlobalConfig::get(const QString& key, const QVariant& def) const {
+    return GlobalConfigBackend::instance()->value(key, def);
+}
+
+void GlobalConfig::set(const QString& key, const QVariant& val) {
+    GlobalConfigBackend::instance()->setValue(key, val);
+}
+
+void GlobalConfig::setBatch(const QVariantMap& patch) {
+    GlobalConfigBackend::instance()->setValues(patch);
+}
+
+QVariantMap GlobalConfig::all() const { return GlobalConfigBackend::instance()->all(); }
+
+void GlobalConfig::reload() { GlobalConfigBackend::instance()->reloadFromDisk(); }

--- a/src/GlobalConfigStore.hpp
+++ b/src/GlobalConfigStore.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <QObject>
+#include <QVariant>
+#include <QVariantMap>
+#include <QReadWriteLock>
+
+namespace wekde
+{
+
+// Process-wide source of truth shared by every wallpaper instance in plasmashell.
+// Backed by ~/.config/wekde/global.json. Not a QML type; reached through GlobalConfig.
+class GlobalConfigBackend : public QObject {
+    Q_OBJECT
+
+public:
+    GlobalConfigBackend();
+    static GlobalConfigBackend* instance();
+
+    QVariant    value(const QString& key, const QVariant& def = {}) const;
+    void        setValue(const QString& key, const QVariant& val);
+    void        setValues(const QVariantMap& patch);
+    QVariantMap all() const;
+    bool        enabled() const;
+    void        reloadFromDisk();
+
+signals:
+    void changed(const QString& key, const QVariant& value);
+    void enabledChanged();
+
+private:
+    QString filePath() const;
+    void    load();
+    void    persist() const;
+    // applies patch in-memory, returns keys whose value actually changed
+    QStringList apply(const QVariantMap& patch);
+
+    QVariantMap            m_data;
+    mutable QReadWriteLock m_lock;
+};
+
+// Lightweight per-instance QML proxy that forwards to the shared backend.
+class GlobalConfig : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+
+public:
+    explicit GlobalConfig(QObject* parent = nullptr);
+
+    bool enabled() const;
+    void setEnabled(bool on);
+
+    Q_INVOKABLE QVariant    get(const QString& key, const QVariant& def = {}) const;
+    Q_INVOKABLE void        set(const QString& key, const QVariant& val);
+    Q_INVOKABLE void        setBatch(const QVariantMap& patch);
+    Q_INVOKABLE QVariantMap all() const;
+    Q_INVOKABLE void        reload();
+
+signals:
+    void changed(const QString& key, const QVariant& value);
+    void enabledChanged();
+};
+
+} // namespace wekde

--- a/src/WallpaperSyncBus.cpp
+++ b/src/WallpaperSyncBus.cpp
@@ -1,0 +1,72 @@
+#include "WallpaperSyncBus.hpp"
+
+#include <QQuickWindow>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
+#include <QUuid>
+#include <QDebug>
+
+using namespace wekde;
+
+namespace
+{
+constexpr auto k_path          = "/WallpaperSync";
+constexpr auto k_interface     = "com.github.catsout.wallpaperEngineKde.Sync";
+constexpr auto k_signal_global = "GlobalConfigChanged";
+} // namespace
+
+WallpaperSyncBus::WallpaperSyncBus(QQuickItem* parent)
+    : QQuickItem(parent), m_id(QUuid::createUuid().toString()) {
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (! bus.isConnected()) {
+        qWarning() << "WallpaperSyncBus: session bus unavailable, cross-process sync disabled";
+        return;
+    }
+
+    bool connected = bus.connect(
+        QString(), k_path, k_interface, k_signal_global, this, SLOT(handleGlobalChange(QString)));
+    if (! connected) {
+        qWarning() << "WallpaperSyncBus: failed to subscribe to sync signal";
+    }
+
+    connect(this, &QQuickItem::windowChanged, this, [this] {
+        connectScreenSignals();
+        emit isPrimaryChanged();
+    });
+    connect(
+        qApp, &QGuiApplication::primaryScreenChanged, this, &WallpaperSyncBus::isPrimaryChanged);
+    connectScreenSignals();
+}
+
+void WallpaperSyncBus::connectScreenSignals() {
+    if (auto* w = window()) {
+        connect(w,
+                &QWindow::screenChanged,
+                this,
+                &WallpaperSyncBus::isPrimaryChanged,
+                Qt::UniqueConnection);
+    }
+}
+
+bool WallpaperSyncBus::isPrimary() const {
+    auto* w = window();
+    if (! w) return false;
+    return w->screen() == QGuiApplication::primaryScreen();
+}
+
+void WallpaperSyncBus::broadcastGlobalChanged() {
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (! bus.isConnected()) return;
+
+    QDBusMessage msg = QDBusMessage::createSignal(k_path, k_interface, k_signal_global);
+    msg << m_id;
+    bus.send(msg);
+}
+
+void WallpaperSyncBus::handleGlobalChange(const QString& senderId) {
+    if (senderId == m_id) return;
+    emit globalConfigChanged();
+}

--- a/src/WallpaperSyncBus.hpp
+++ b/src/WallpaperSyncBus.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <QQuickItem>
+#include <QString>
+
+namespace wekde
+{
+
+class WallpaperSyncBus : public QQuickItem {
+    Q_OBJECT
+    Q_PROPERTY(bool isPrimary READ isPrimary NOTIFY isPrimaryChanged)
+
+public:
+    WallpaperSyncBus(QQuickItem* parent = nullptr);
+
+    bool isPrimary() const;
+
+    // Wakes wallpaper instances living in other processes (e.g. the config
+    // dialog) so they reload the global config from disk.
+    Q_INVOKABLE void broadcastGlobalChanged();
+
+signals:
+    void globalConfigChanged();
+    void isPrimaryChanged();
+
+private slots:
+    void handleGlobalChange(const QString& senderId);
+
+private:
+    void connectScreenSignals();
+
+    QString m_id;
+};
+
+} // namespace wekde

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -93,6 +93,11 @@ public:
     }
 
     ~TextureNode() override {
+        // At plasmashell exit the SceneObject is leaked (its destructor never runs),
+        // so the render thread would keep running DRAW against torn-down GL/Vulkan
+        // state. The texture node IS destroyed on teardown, so stop and join the
+        // render loop here before this node and its resources go away.
+        m_scene->stopRender();
         for (auto& item : texs_map) {
             auto& exh = item.second;
             // close(exh.fd);

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -141,7 +141,7 @@ public slots:
     void newTexture() {
         if (! m_scene->inited() || m_scene->exSwapchain() == nullptr) return;
 
-        wallpaper::ExHandle* exh = m_scene->exSwapchain()->eatFrame();
+        wallpaper::ExHandle* exh = m_scene->exSwapchain()->eatFrame(m_last_frame_id);
         if (exh != nullptr) {
             int id = exh->id();
             if (texs_map.count(id) == 0) {
@@ -185,6 +185,7 @@ private:
     EatFrameOp        m_eatFrameOp;
     QQuickWindow*     m_window;
     std::atomic<bool> m_first_frame;
+    std::uint64_t     m_last_frame_id { 0 };
 
     GlExtra m_glex;
 

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -75,10 +75,12 @@ class TextureNode : public QObject, public QSGSimpleTextureNode {
     Q_OBJECT
 public:
     typedef std::function<QSGTexture*(QQuickWindow*)> EatFrameOp;
-    TextureNode(QQuickWindow* window, sp_scene_t scene, bool valid, EatFrameOp eatFrameOp)
+    TextureNode(QQuickWindow* window, sp_scene_t scene, bool valid, bool share_gpu,
+                EatFrameOp eatFrameOp)
         : m_texture(nullptr),
           m_scene(scene),
           m_enable_valid(valid),
+          m_share_gpu(share_gpu),
           m_eatFrameOp(eatFrameOp),
           m_window(window),
           m_first_frame(false) {
@@ -110,6 +112,7 @@ public:
         wallpaper::RenderInitInfo info;
         info.enable_valid_layer = m_enable_valid;
         info.offscreen          = true;
+        info.share_gpu          = m_share_gpu;
         info.offscreen_tiling   = m_glex.tiling();
         info.uuid               = m_glex.uuid();
         info.width              = w;
@@ -175,6 +178,7 @@ public slots:
 private:
     sp_scene_t m_scene;
     bool       m_enable_valid;
+    bool       m_share_gpu;
 
     QSGTexture*       m_init_texture;
     QSGTexture*       m_texture;
@@ -212,9 +216,10 @@ void SceneObject::resizeFb() {
 QSGNode* SceneObject::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) {
     TextureNode* node = static_cast<TextureNode*>(oldNode);
     if (! node) {
-        node = new TextureNode(window(), m_scene, m_enable_valid, [this](QQuickWindow* window) {
-            return (QSGTexture*)nullptr;
-        });
+        node =
+            new TextureNode(window(), m_scene, m_enable_valid, m_share_gpu, [this](QQuickWindow*) {
+                return (QSGTexture*)nullptr;
+            });
         if (node->initGl()) {
             node->initVulkan(width() * window()->devicePixelRatio(),
                              height() * window()->devicePixelRatio());
@@ -299,6 +304,12 @@ void SceneObject::setCachePasses(bool value) {
     if (m_cachePasses == value) return;
     m_cachePasses = value;
     SET_PROPERTY(Bool, wallpaper::PROPERTY_CACHE_PASSES, value);
+}
+
+bool SceneObject::shareGpu() const { return m_share_gpu; }
+void SceneObject::setShareGpu(bool value) {
+    // Consumed when the render node is created; takes effect on next load.
+    m_share_gpu = value;
 }
 
 QString SceneObject::userProperties() const { return m_userProperties; }

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -150,13 +150,11 @@ public slots:
                         exh->height,
                         exh->fd);
                 ExTex ex_tex;
-                int   fd    = exh->fd;
                 uint  gltex = m_glex.genExTexture(*exh);
 
                 ex_tex.gltex = gltex;
                 ex_tex.qsg   = createTextureFromGl(gltex, QSize(exh->width, exh->height), m_window);
                 texs_map[id] = ex_tex;
-                close(fd);
             }
             auto& newtex = texs_map.at(id);
             if (newtex.qsg != nullptr)

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -294,6 +294,13 @@ void SceneObject::setMuted(bool value) {
     SET_PROPERTY(Bool, wallpaper::PROPERTY_MUTED, value);
 }
 
+bool SceneObject::cachePasses() const { return m_cachePasses; }
+void SceneObject::setCachePasses(bool value) {
+    if (m_cachePasses == value) return;
+    m_cachePasses = value;
+    SET_PROPERTY(Bool, wallpaper::PROPERTY_CACHE_PASSES, value);
+}
+
 QString SceneObject::userProperties() const { return m_userProperties; }
 
 void SceneObject::setUserProperties(const QString& value) {

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -76,11 +76,12 @@ class TextureNode : public QObject, public QSGSimpleTextureNode {
 public:
     typedef std::function<QSGTexture*(QQuickWindow*)> EatFrameOp;
     TextureNode(QQuickWindow* window, sp_scene_t scene, bool valid, bool share_gpu,
-                EatFrameOp eatFrameOp)
+                bool mirror_scene, EatFrameOp eatFrameOp)
         : m_texture(nullptr),
           m_scene(scene),
           m_enable_valid(valid),
           m_share_gpu(share_gpu),
+          m_mirror_scene(mirror_scene),
           m_eatFrameOp(eatFrameOp),
           m_window(window),
           m_first_frame(false) {
@@ -118,6 +119,7 @@ public:
         info.enable_valid_layer = m_enable_valid;
         info.offscreen          = true;
         info.share_gpu          = m_share_gpu;
+        info.mirror_scene       = m_mirror_scene;
         info.offscreen_tiling   = m_glex.tiling();
         info.uuid               = m_glex.uuid();
         info.width              = w;
@@ -182,6 +184,7 @@ private:
     sp_scene_t m_scene;
     bool       m_enable_valid;
     bool       m_share_gpu;
+    bool       m_mirror_scene;
 
     QSGTexture*       m_init_texture;
     QSGTexture*       m_texture;
@@ -220,8 +223,8 @@ void SceneObject::resizeFb() {
 QSGNode* SceneObject::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) {
     TextureNode* node = static_cast<TextureNode*>(oldNode);
     if (! node) {
-        node =
-            new TextureNode(window(), m_scene, m_enable_valid, m_share_gpu, [this](QQuickWindow*) {
+        node = new TextureNode(
+            window(), m_scene, m_enable_valid, m_share_gpu, m_mirror_scene, [this](QQuickWindow*) {
                 return (QSGTexture*)nullptr;
             });
         if (node->initGl()) {
@@ -314,6 +317,12 @@ bool SceneObject::shareGpu() const { return m_share_gpu; }
 void SceneObject::setShareGpu(bool value) {
     // Consumed when the render node is created; takes effect on next load.
     m_share_gpu = value;
+}
+
+bool SceneObject::mirrorScene() const { return m_mirror_scene; }
+void SceneObject::setMirrorScene(bool value) {
+    // Consumed when the render node is created; takes effect on next load.
+    m_mirror_scene = value;
 }
 
 QString SceneObject::userProperties() const { return m_userProperties; }

--- a/src/backend_scene/qml_helper/SceneBackend.cpp
+++ b/src/backend_scene/qml_helper/SceneBackend.cpp
@@ -146,9 +146,13 @@ signals:
 
 public slots:
     void newTexture() {
-        if (! m_scene->inited() || m_scene->exSwapchain() == nullptr) return;
+        if (! m_scene->inited()) return;
+        // Hold a shared_ptr to the frame source for the whole eat: the render thread
+        // may re-elect and swap the mirror source while we read it.
+        auto swapchain = m_scene->currentSwapchain();
+        if (! swapchain) return;
 
-        wallpaper::ExHandle* exh = m_scene->exSwapchain()->eatFrame(m_last_frame_id);
+        wallpaper::ExHandle* exh = swapchain->eatFrame(m_last_frame_id);
         if (exh != nullptr) {
             int id = exh->id();
             if (texs_map.count(id) == 0) {

--- a/src/backend_scene/qml_helper/SceneBackend.hpp
+++ b/src/backend_scene/qml_helper/SceneBackend.hpp
@@ -24,6 +24,7 @@ class SceneObject : public QQuickItem {
     Q_PROPERTY(bool muted READ muted WRITE setMuted)
     Q_PROPERTY(bool cachePasses READ cachePasses WRITE setCachePasses)
     Q_PROPERTY(bool shareGpu READ shareGpu WRITE setShareGpu)
+    Q_PROPERTY(bool mirrorScene READ mirrorScene WRITE setMirrorScene)
     Q_PROPERTY(QString userProperties READ userProperties WRITE setUserProperties NOTIFY
                    userPropertiesChanged)
 public:
@@ -50,6 +51,7 @@ public:
     bool    muted() const;
     bool    cachePasses() const;
     bool    shareGpu() const;
+    bool    mirrorScene() const;
     QString userProperties() const;
 
     void setFps(int);
@@ -59,6 +61,7 @@ public:
     void setMuted(bool);
     void setCachePasses(bool);
     void setShareGpu(bool);
+    void setMirrorScene(bool);
     void setUserProperties(const QString&);
 
     // debug
@@ -99,6 +102,7 @@ private:
     bool    m_muted { false };
     bool    m_cachePasses { true };
     bool    m_share_gpu { true };
+    bool    m_mirror_scene { false };
     QString m_userProperties;
 
 public:

--- a/src/backend_scene/qml_helper/SceneBackend.hpp
+++ b/src/backend_scene/qml_helper/SceneBackend.hpp
@@ -23,6 +23,7 @@ class SceneObject : public QQuickItem {
     Q_PROPERTY(float volume READ volume WRITE setVolume NOTIFY volumeChanged)
     Q_PROPERTY(bool muted READ muted WRITE setMuted)
     Q_PROPERTY(bool cachePasses READ cachePasses WRITE setCachePasses)
+    Q_PROPERTY(bool shareGpu READ shareGpu WRITE setShareGpu)
     Q_PROPERTY(QString userProperties READ userProperties WRITE setUserProperties NOTIFY
                    userPropertiesChanged)
 public:
@@ -48,6 +49,7 @@ public:
     float   volume() const;
     bool    muted() const;
     bool    cachePasses() const;
+    bool    shareGpu() const;
     QString userProperties() const;
 
     void setFps(int);
@@ -56,6 +58,7 @@ public:
     void setVolume(float);
     void setMuted(bool);
     void setCachePasses(bool);
+    void setShareGpu(bool);
     void setUserProperties(const QString&);
 
     // debug
@@ -95,6 +98,7 @@ private:
     float   m_volume { 1.0f };
     bool    m_muted { false };
     bool    m_cachePasses { true };
+    bool    m_share_gpu { true };
     QString m_userProperties;
 
 public:

--- a/src/backend_scene/qml_helper/SceneBackend.hpp
+++ b/src/backend_scene/qml_helper/SceneBackend.hpp
@@ -22,6 +22,7 @@ class SceneObject : public QQuickItem {
     Q_PROPERTY(float speed READ speed WRITE setSpeed NOTIFY speedChanged)
     Q_PROPERTY(float volume READ volume WRITE setVolume NOTIFY volumeChanged)
     Q_PROPERTY(bool muted READ muted WRITE setMuted)
+    Q_PROPERTY(bool cachePasses READ cachePasses WRITE setCachePasses)
     Q_PROPERTY(QString userProperties READ userProperties WRITE setUserProperties NOTIFY
                    userPropertiesChanged)
 public:
@@ -46,6 +47,7 @@ public:
     float   speed() const;
     float   volume() const;
     bool    muted() const;
+    bool    cachePasses() const;
     QString userProperties() const;
 
     void setFps(int);
@@ -53,6 +55,7 @@ public:
     void setSpeed(float);
     void setVolume(float);
     void setMuted(bool);
+    void setCachePasses(bool);
     void setUserProperties(const QString&);
 
     // debug
@@ -91,6 +94,7 @@ private:
     float   m_speed { 1.0f };
     float   m_volume { 1.0f };
     bool    m_muted { false };
+    bool    m_cachePasses { true };
     QString m_userProperties;
 
 public:

--- a/src/backend_scene/qml_helper/glExtra.cpp
+++ b/src/backend_scene/qml_helper/glExtra.cpp
@@ -211,6 +211,15 @@ uint GlExtra::genExTexture(ExHandle& handle) {
         return 0;
     }
 
+    // Import takes ownership of the fd, so dup it: the ExHandle's fd is owned by
+    // the swapchain and may be imported by several screens (mirroring). Done before
+    // the context switch so a failure here doesn't leave the wrong GL context current.
+    int dupfd = ::dup(handle.fd);
+    if (dupfd < 0) {
+        LOG_ERROR("gl: failed to dup ExHandle fd %d", handle.fd);
+        return 0;
+    }
+
     QOpenGLContext* prev_ctx     = nullptr;
     QSurface*       prev_surface = nullptr;
 
@@ -219,14 +228,6 @@ uint GlExtra::genExTexture(ExHandle& handle) {
         prev_ctx     = QOpenGLContext::currentContext();
         prev_surface = prev_ctx ? prev_ctx->surface() : nullptr;
         m_shared_ctx->makeCurrent(m_surface);
-    }
-
-    // Import takes ownership of the fd, so dup it: the ExHandle's fd is owned by
-    // the swapchain and may be imported by several screens (mirroring).
-    int dupfd = ::dup(handle.fd);
-    if (dupfd < 0) {
-        LOG_ERROR("gl: failed to dup ExHandle fd %d", handle.fd);
-        return 0;
     }
 
     uint memobject, tex;

--- a/src/backend_scene/qml_helper/glExtra.cpp
+++ b/src/backend_scene/qml_helper/glExtra.cpp
@@ -1,6 +1,7 @@
 #include "glExtra.hpp"
 #include <glad/glad.h>
 #include <vector>
+#include <unistd.h>
 #include "Utils/Logging.h"
 
 #include <QtGui/QOpenGLContext>
@@ -220,9 +221,17 @@ uint GlExtra::genExTexture(ExHandle& handle) {
         m_shared_ctx->makeCurrent(m_surface);
     }
 
+    // Import takes ownership of the fd, so dup it: the ExHandle's fd is owned by
+    // the swapchain and may be imported by several screens (mirroring).
+    int dupfd = ::dup(handle.fd);
+    if (dupfd < 0) {
+        LOG_ERROR("gl: failed to dup ExHandle fd %d", handle.fd);
+        return 0;
+    }
+
     uint memobject, tex;
     glCreateMemoryObjectsEXT(1, &memobject);
-    glImportMemoryFdEXT(memobject, handle.size, GL_HANDLE_TYPE_OPAQUE_FD_EXT, handle.fd);
+    glImportMemoryFdEXT(memobject, handle.size, GL_HANDLE_TYPE_OPAQUE_FD_EXT, dupfd);
     // NVIDIA generates spurious GL_INVALID_ENUM here on both GL 3.2 and 4.x contexts.
     // Subsequent checks after glTexParameteri/glTexStorageMem2DEXT catch real errors.
     glGetError();
@@ -243,7 +252,6 @@ uint GlExtra::genExTexture(ExHandle& handle) {
     CHECK_GL_ERROR_IF_DEBUG()
 
     glBindTexture(GL_TEXTURE_2D, 0);
-    handle.fd = -1;
 
     // Switch back to Plasma context
     if (prev_ctx && prev_surface) {

--- a/src/backend_scene/src/Scene/include/Scene/Scene.h
+++ b/src/backend_scene/src/Scene/include/Scene/Scene.h
@@ -26,6 +26,12 @@ public:
     std::unordered_map<std::string, SceneTexture>      textures;
     std::unordered_map<std::string, SceneRenderTarget> renderTargets;
 
+    // static-pass caching: whether a render target is written only by passes
+    // whose output never changes after the first frame. Filled during prepare
+    // (topological order). cache_passes gates the whole optimization.
+    bool                                  cache_passes { true };
+    std::unordered_map<std::string, bool> rt_frame_static;
+
     std::unordered_map<std::string, std::shared_ptr<SceneCamera>> cameras;
     std::unordered_map<std::string, std::vector<std::string>>     linkedCameras;
 

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -221,6 +221,9 @@ private:
 
     void rebuildAndDecide() {
         if (! m_scene) return;
+        // Release the old passes/render targets/staging refs before allocating the
+        // replacement graph (same as the SET_SCENE path).
+        if (m_rg) m_render->clearLastRenderGraph();
         m_rg = sceneToRenderGraph(*m_scene);
         m_render->compileRenderGraph(*m_scene, *m_rg);
         m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
@@ -255,6 +258,9 @@ private:
                 m_render->releaseMirror();
                 rebuildAndDecide();
             } else {
+                // Keep this screen's scene clock advancing while mirroring so a
+                // later re-election doesn't restart a time-based wallpaper from ~0.
+                if (m_scene) m_scene->PassFrameTime(frame_timer.IdeaTime() * m_speed);
                 m_render->drawFrame(*m_scene);
             }
             frame_timer.FrameEnd();

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -82,7 +82,13 @@ public:
 
 public:
     MainHandler();
-    virtual ~MainHandler() {};
+    virtual ~MainHandler();
+
+    // Quiesce the render thread: stop the frame timer, stop emitting redraws, and
+    // join both loops so no DRAW runs while the scene/device are torn down. Safe to
+    // call more than once. Called from the texture node teardown because at
+    // plasmashell exit the SceneObject (and thus this handler) is never destroyed.
+    void stopRender();
 
     bool init();
     auto renderHandler() const { return m_render_handler; }
@@ -177,6 +183,10 @@ public:
     }
 
     ExSwapchain* exSwapchain() const { return m_render->exSwapchain(); }
+
+    void clearRedrawCallback() { m_render->clearRedrawCallback(); }
+
+    void stopRendering() { frame_timer.Stop(); }
 
     bool renderInited() const { return m_render->inited(); }
 
@@ -320,6 +330,17 @@ private:
 
     std::atomic<std::array<float, 2>> m_mouse_pos { std::array { 0.5f, 0.5f } };
 };
+
+void MainHandler::stopRender() {
+    if (m_render_handler) {
+        m_render_handler->stopRendering();
+        m_render_handler->clearRedrawCallback();
+    }
+    if (m_render_loop) m_render_loop->stop();
+    if (m_main_loop) m_main_loop->stop();
+}
+
+MainHandler::~MainHandler() { stopRender(); }
 } // namespace wallpaper
 
 SceneWallpaper::SceneWallpaper(): m_main_handler(std::make_shared<MainHandler>()) {}
@@ -382,6 +403,12 @@ BASIC_TYPE(Object, std::shared_ptr<void>);
 ExSwapchain* SceneWallpaper::exSwapchain() const {
     return m_main_handler->renderHandler()->exSwapchain();
 }
+
+void SceneWallpaper::clearRedrawCallback() {
+    m_main_handler->renderHandler()->clearRedrawCallback();
+}
+
+void SceneWallpaper::stopRender() { m_main_handler->stopRender(); }
 
 MHANDLER_CMD_IMPL(MainHandler, LOAD_SCENE) {
     if (m_render_handler->renderInited()) {

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -188,6 +188,8 @@ public:
 
     void stopRendering() { frame_timer.Stop(); }
 
+    void releaseMirrorGroup() { m_render->releaseMirror(); }
+
     bool renderInited() const { return m_render->inited(); }
 
     void setMousePos(double x, double y) { m_mouse_pos.store(std::array { (float)x, (float)y }); }
@@ -338,6 +340,9 @@ void MainHandler::stopRender() {
     }
     if (m_render_loop) m_render_loop->stop();
     if (m_main_loop) m_main_loop->stop();
+    // After the loops are joined (no render thread left), drop any mirror-group
+    // membership so a primary leaving lets the remaining screens re-elect.
+    if (m_render_handler) m_render_handler->releaseMirrorGroup();
 }
 
 MainHandler::~MainHandler() { stopRender(); }

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -89,6 +89,7 @@ public:
     void sendCmdLoadScene();
     void sendFirstFrameOk();
     bool isGenGraphviz() const { return m_gen_graphviz; }
+    bool cachePasses() const { return m_cache_passes; }
 
 private:
     void loadScene();
@@ -105,6 +106,7 @@ private:
     std::string m_source;
     std::string m_cache_path;
     bool        m_gen_graphviz { false };
+    bool        m_cache_passes { true };
 
     WPSceneParser                        m_scene_parser;
     std::unique_ptr<audio::SoundManager> m_sound_manager;
@@ -215,6 +217,7 @@ private:
     }
     MHANDLER_CMD(SET_SCENE) {
         if (msg->findObject("scene", &m_scene)) {
+            m_scene->cache_passes = main_handler.cachePasses();
             if (m_rg) m_render->clearLastRenderGraph();
             m_rg = sceneToRenderGraph(*m_scene);
 
@@ -378,6 +381,16 @@ MHANDLER_CMD_IMPL(MainHandler, SET_PROPERTY) {
                 // Skip reload if json is empty - this means wallpaper is changing
                 if (! json.empty() && ! m_source.empty() && ! m_assets.empty()) {
                     LOG_INFO("Reloading scene to apply user properties: %s", json.c_str());
+                    CALL_MHANDLER_CMD(LOAD_SCENE, msg);
+                }
+            }
+        } else if (property == PROPERTY_CACHE_PASSES) {
+            bool value { true };
+            msg->findBool("value", &value);
+            if (m_cache_passes != value) {
+                m_cache_passes = value;
+                // rebuild the render graph so the new setting takes effect live
+                if (! m_source.empty() && ! m_assets.empty()) {
                     CALL_MHANDLER_CMD(LOAD_SCENE, msg);
                 }
             }

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -36,9 +36,10 @@ using namespace wallpaper;
 
 namespace
 {
-bool MirrorEnabled() {
-    const char* e = std::getenv("WP_MIRROR");
-    return e != nullptr && e[0] != '0' && e[0] != '\0';
+// The WP_MIRROR env var overrides the per-wallpaper setting (0 forces off).
+bool MirrorEnabled(bool requested) {
+    if (const char* e = std::getenv("WP_MIRROR")) return e[0] != '0' && e[0] != '\0';
+    return requested;
 }
 
 std::string UuidHex(std::span<const std::uint8_t> uuid) {
@@ -208,8 +209,9 @@ private:
     void decideFrameSource() {
         auto* wpUpdater = static_cast<WPShaderValueUpdater*>(m_scene->shaderValueUpdater.get());
         bool  mouse_dep = wpUpdater->MouseDependent();
-        std::string key = (MirrorEnabled() && ! mouse_dep) ? buildMirrorKey() : std::string {};
-        m_mirror        = ! m_render->beginFrameSource(key);
+        std::string key =
+            (MirrorEnabled(m_mirror_setting) && ! mouse_dep) ? buildMirrorKey() : std::string {};
+        m_mirror = ! m_render->beginFrameSource(key);
         LOG_INFO("scene '%s' mouse_dependent=%d mirror=%d",
                  m_scene->scene_id.c_str(),
                  (int)mouse_dep,
@@ -302,9 +304,10 @@ private:
     MHANDLER_CMD(INIT_VULKAN) {
         std::shared_ptr<RenderInitInfo> info;
         if (msg->findObject("info", &info)) {
-            m_width    = info->width;
-            m_height   = info->height;
-            m_uuid_hex = UuidHex(info->uuid);
+            m_width          = info->width;
+            m_height         = info->height;
+            m_uuid_hex       = UuidHex(info->uuid);
+            m_mirror_setting = info->mirror_scene;
             m_render->init(*info);
 
             // inited, callback to laod scene
@@ -326,6 +329,7 @@ private:
     FillMode m_fillmode { FillMode::ASPECTCROP };
 
     bool        m_mirror { false };
+    bool        m_mirror_setting { false };
     std::string m_uuid_hex;
     uint16_t    m_width { 0 };
     uint16_t    m_height { 0 };

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -224,6 +224,16 @@ private:
             if (main_handler.isGenGraphviz()) m_rg->ToGraphviz("graph.dot");
             m_render->compileRenderGraph(*m_scene, *m_rg);
             m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
+
+            {
+                auto* wpUpdater =
+                    static_cast<WPShaderValueUpdater*>(m_scene->shaderValueUpdater.get());
+                bool mouse_dep = wpUpdater->MouseDependent();
+                LOG_INFO("scene '%s' mouse_dependent=%d (mirror-%s)",
+                         m_scene->scene_id.c_str(),
+                         (int)mouse_dep,
+                         mouse_dep ? "ineligible" : "eligible");
+            }
         }
     }
     MHANDLER_CMD(SET_SPEED) { msg->findFloat("value", &m_speed); }

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -183,7 +183,8 @@ public:
         }
     }
 
-    ExSwapchain* exSwapchain() const { return m_render->exSwapchain(); }
+    ExSwapchain*                 exSwapchain() const { return m_render->exSwapchain(); }
+    std::shared_ptr<ExSwapchain> currentSwapchain() const { return m_render->currentSwapchain(); }
 
     void clearRedrawCallback() { m_render->clearRedrawCallback(); }
 
@@ -218,6 +219,23 @@ private:
                  (int)m_mirror);
     }
 
+    void rebuildAndDecide() {
+        if (! m_scene) return;
+        m_rg = sceneToRenderGraph(*m_scene);
+        m_render->compileRenderGraph(*m_scene, *m_rg);
+        m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
+        decideFrameSource();
+    }
+
+    // A live change to a mirror-key input (fillmode/speed) must re-run the election:
+    // a mirroring secondary now differs from its primary and should render its own,
+    // and a primary's group must re-form under the new key.
+    void onMirrorKeyChanged() {
+        if (! (m_scene && renderInited() && MirrorEnabled(m_mirror_setting))) return;
+        m_render->releaseMirror();
+        rebuildAndDecide();
+    }
+
     MHANDLER_CMD(STOP) {
         bool stop { false };
         if (msg->findBool("value", &stop)) {
@@ -235,12 +253,7 @@ private:
                 // the first surviving screen for this group becomes the new primary.
                 LOG_INFO("mirror: primary gone, screen re-electing");
                 m_render->releaseMirror();
-                if (m_scene) {
-                    m_rg = sceneToRenderGraph(*m_scene);
-                    m_render->compileRenderGraph(*m_scene, *m_rg);
-                    m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
-                    decideFrameSource();
-                }
+                rebuildAndDecide();
             } else {
                 m_render->drawFrame(*m_scene);
             }
@@ -279,10 +292,13 @@ private:
     }
     MHANDLER_CMD(SET_FILLMODE) {
         int32_t value;
-        if (msg->findInt32("value", &value)) {
+        if (msg->findInt32("value", &value) && (FillMode)value != m_fillmode) {
             m_fillmode = (FillMode)value;
             if (m_scene && renderInited()) {
-                m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
+                if (MirrorEnabled(m_mirror_setting))
+                    onMirrorKeyChanged();
+                else
+                    m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
             }
         }
     }
@@ -300,7 +316,13 @@ private:
             decideFrameSource();
         }
     }
-    MHANDLER_CMD(SET_SPEED) { msg->findFloat("value", &m_speed); }
+    MHANDLER_CMD(SET_SPEED) {
+        float v { 1.0f };
+        if (msg->findFloat("value", &v) && v != m_speed) {
+            m_speed = v;
+            onMirrorKeyChanged();
+        }
+    }
     MHANDLER_CMD(INIT_VULKAN) {
         std::shared_ptr<RenderInitInfo> info;
         if (msg->findObject("info", &info)) {
@@ -411,6 +433,10 @@ BASIC_TYPE(Object, std::shared_ptr<void>);
 
 ExSwapchain* SceneWallpaper::exSwapchain() const {
     return m_main_handler->renderHandler()->exSwapchain();
+}
+
+std::shared_ptr<ExSwapchain> SceneWallpaper::currentSwapchain() const {
+    return m_main_handler->renderHandler()->currentSwapchain();
 }
 
 void SceneWallpaper::clearRedrawCallback() {

--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -23,6 +23,7 @@
 #include "VulkanRender/SceneToRenderGraph.hpp"
 #include "VulkanRender/VulkanRender.hpp"
 #include <atomic>
+#include <sstream>
 
 using namespace wallpaper;
 
@@ -35,6 +36,22 @@ using namespace wallpaper;
 
 namespace
 {
+bool MirrorEnabled() {
+    const char* e = std::getenv("WP_MIRROR");
+    return e != nullptr && e[0] != '0' && e[0] != '\0';
+}
+
+std::string UuidHex(std::span<const std::uint8_t> uuid) {
+    static const char* k = "0123456789abcdef";
+    std::string        s;
+    s.reserve(uuid.size() * 2);
+    for (auto b : uuid) {
+        s.push_back(k[b >> 4]);
+        s.push_back(k[b & 0xf]);
+    }
+    return s;
+}
+
 template<typename T>
 void AddMsgCmd(looper::Message& msg, T cmd) {
     msg.setInt32("cmd", (int32_t)cmd);
@@ -86,10 +103,11 @@ public:
         }
     }
 
-    void sendCmdLoadScene();
-    void sendFirstFrameOk();
-    bool isGenGraphviz() const { return m_gen_graphviz; }
-    bool cachePasses() const { return m_cache_passes; }
+    void               sendCmdLoadScene();
+    void               sendFirstFrameOk();
+    bool               isGenGraphviz() const { return m_gen_graphviz; }
+    bool               cachePasses() const { return m_cache_passes; }
+    const std::string& userProps() const { return m_user_props_json; }
 
 private:
     void loadScene();
@@ -165,6 +183,27 @@ public:
     void setMousePos(double x, double y) { m_mouse_pos.store(std::array { (float)x, (float)y }); }
 
 private:
+    std::string buildMirrorKey() const {
+        if (! m_scene) return {};
+        std::ostringstream os;
+        os << m_uuid_hex << '|' << m_scene->scene_id << '|' << m_width << 'x' << m_height << '|'
+           << (int)m_fillmode << '|' << m_speed << '|' << main_handler.userProps();
+        return os.str();
+    }
+
+    // After the graph is compiled, decide whether this screen renders or mirrors,
+    // and remember the result for the draw loop.
+    void decideFrameSource() {
+        auto* wpUpdater = static_cast<WPShaderValueUpdater*>(m_scene->shaderValueUpdater.get());
+        bool  mouse_dep = wpUpdater->MouseDependent();
+        std::string key = (MirrorEnabled() && ! mouse_dep) ? buildMirrorKey() : std::string {};
+        m_mirror        = ! m_render->beginFrameSource(key);
+        LOG_INFO("scene '%s' mouse_dependent=%d mirror=%d",
+                 m_scene->scene_id.c_str(),
+                 (int)mouse_dep,
+                 (int)m_mirror);
+    }
+
     MHANDLER_CMD(STOP) {
         bool stop { false };
         if (msg->findBool("value", &stop)) {
@@ -176,6 +215,24 @@ private:
     }
     MHANDLER_CMD(DRAW) {
         frame_timer.FrameBegin();
+        if (m_mirror) {
+            if (m_render->mirrorLost()) {
+                // Primary went away: rebuild our graph and re-run the election;
+                // the first surviving screen for this group becomes the new primary.
+                LOG_INFO("mirror: primary gone, screen re-electing");
+                m_render->releaseMirror();
+                if (m_scene) {
+                    m_rg = sceneToRenderGraph(*m_scene);
+                    m_render->compileRenderGraph(*m_scene, *m_rg);
+                    m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
+                    decideFrameSource();
+                }
+            } else {
+                m_render->drawFrame(*m_scene);
+            }
+            frame_timer.FrameEnd();
+            return;
+        }
         if (m_rg) {
             // LOG_INFO("frame info, fps: %.1f, frametime: %.1f", 1.0f, 1000.0f*m_scene->frameTime);
             m_scene->shaderValueUpdater->FrameBegin();
@@ -218,6 +275,7 @@ private:
     MHANDLER_CMD(SET_SCENE) {
         if (msg->findObject("scene", &m_scene)) {
             m_scene->cache_passes = main_handler.cachePasses();
+            m_render->releaseMirror();
             if (m_rg) m_render->clearLastRenderGraph();
             m_rg = sceneToRenderGraph(*m_scene);
 
@@ -225,21 +283,16 @@ private:
             m_render->compileRenderGraph(*m_scene, *m_rg);
             m_render->UpdateCameraFillMode(*m_scene, m_fillmode);
 
-            {
-                auto* wpUpdater =
-                    static_cast<WPShaderValueUpdater*>(m_scene->shaderValueUpdater.get());
-                bool mouse_dep = wpUpdater->MouseDependent();
-                LOG_INFO("scene '%s' mouse_dependent=%d (mirror-%s)",
-                         m_scene->scene_id.c_str(),
-                         (int)mouse_dep,
-                         mouse_dep ? "ineligible" : "eligible");
-            }
+            decideFrameSource();
         }
     }
     MHANDLER_CMD(SET_SPEED) { msg->findFloat("value", &m_speed); }
     MHANDLER_CMD(INIT_VULKAN) {
         std::shared_ptr<RenderInitInfo> info;
         if (msg->findObject("info", &info)) {
+            m_width    = info->width;
+            m_height   = info->height;
+            m_uuid_hex = UuidHex(info->uuid);
             m_render->init(*info);
 
             // inited, callback to laod scene
@@ -259,6 +312,11 @@ private:
     std::unique_ptr<rg::RenderGraph>      m_rg { nullptr };
 
     FillMode m_fillmode { FillMode::ASPECTCROP };
+
+    bool        m_mirror { false };
+    std::string m_uuid_hex;
+    uint16_t    m_width { 0 };
+    uint16_t    m_height { 0 };
 
     std::atomic<std::array<float, 2>> m_mouse_pos { std::array { 0.5f, 0.5f } };
 };

--- a/src/backend_scene/src/SceneWallpaper.hpp
+++ b/src/backend_scene/src/SceneWallpaper.hpp
@@ -47,6 +47,8 @@ public:
     void setPropertyObject(std::string_view, std::shared_ptr<void>);
 
     ExSwapchain* exSwapchain() const;
+    // Thread-safe snapshot of the current frame source; hold it across eatFrame().
+    std::shared_ptr<ExSwapchain> currentSwapchain() const;
 
     // Stops the render loop from invoking its redraw callback; call before the
     // owning texture node is destroyed (teardown ordering).

--- a/src/backend_scene/src/SceneWallpaper.hpp
+++ b/src/backend_scene/src/SceneWallpaper.hpp
@@ -48,6 +48,14 @@ public:
 
     ExSwapchain* exSwapchain() const;
 
+    // Stops the render loop from invoking its redraw callback; call before the
+    // owning texture node is destroyed (teardown ordering).
+    void clearRedrawCallback();
+
+    // Stops the frame timer and joins the render/main loops so no render-thread
+    // work runs during teardown. Called from texture-node destruction.
+    void stopRender();
+
 private:
     bool m_inited { false };
 

--- a/src/backend_scene/src/SceneWallpaper.hpp
+++ b/src/backend_scene/src/SceneWallpaper.hpp
@@ -21,6 +21,7 @@ constexpr std::string_view PROPERTY_MUTED                = "muted";
 constexpr std::string_view PROPERTY_CACHE_PATH           = "cache_path";
 constexpr std::string_view PROPERTY_FIRST_FRAME_CALLBACK = "first_frame_callback";
 constexpr std::string_view PROPERTY_USER_PROPS           = "user_props";
+constexpr std::string_view PROPERTY_CACHE_PASSES         = "cache_passes";
 
 #include "Core/NoCopyMove.hpp"
 class MainHandler;

--- a/src/backend_scene/src/SceneWallpaperSurface.hpp
+++ b/src/backend_scene/src/SceneWallpaperSurface.hpp
@@ -20,6 +20,7 @@ struct RenderInitInfo {
     bool enable_valid_layer { false };
     bool offscreen { false };
     bool share_gpu { true };
+    bool mirror_scene { false };
 
     std::span<const std::uint8_t> uuid;
     TexTiling                     offscreen_tiling { TexTiling::OPTIMAL };

--- a/src/backend_scene/src/SceneWallpaperSurface.hpp
+++ b/src/backend_scene/src/SceneWallpaperSurface.hpp
@@ -19,6 +19,7 @@ struct VulkanSurfaceInfo {
 struct RenderInitInfo {
     bool enable_valid_layer { false };
     bool offscreen { false };
+    bool share_gpu { true };
 
     std::span<const std::uint8_t> uuid;
     TexTiling                     offscreen_tiling { TexTiling::OPTIMAL };

--- a/src/backend_scene/src/Swapchain/TripleSwapchain.hpp
+++ b/src/backend_scene/src/Swapchain/TripleSwapchain.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <atomic>
+#include <cstdint>
 #include "Core/NoCopyMove.hpp"
 
 namespace wallpaper
@@ -10,16 +11,32 @@ class TripleSwapchain : NoCopy, NoMove {
 public:
     virtual ~TripleSwapchain() = default;
 
-    T* eatFrame() {
-        if (! dirty().exchange(false)) return nullptr;
-        presented() = ready().exchange(presented());
-        return presented();
+    // Consumer side. Returns the latest published frame if it differs from the
+    // caller's last_seen id, otherwise nullptr. Multiple consumers may call this
+    // concurrently, each holding its own last_seen, so one rendered frame can be
+    // displayed on several screens (mirroring). The producer never renders into
+    // the published slot, so the returned handle stays valid while the next frame
+    // renders into a different slot.
+    T* eatFrame(uint64_t& last_seen) {
+        uint64_t cur = m_pub_id.load(std::memory_order_acquire);
+        if (cur == last_seen) return nullptr;
+        last_seen = cur;
+        return presented().load(std::memory_order_acquire);
     }
+
+    // Producer side. Publishes the just-rendered (inprogress) slot and rotates the
+    // previously published slot into a one-frame cooldown before it can be reused
+    // as the next render target.
     void renderFrame() {
-        inprogress() = ready().exchange(inprogress());
-        dirty().exchange(true);
+        T* just  = inprogress().load(std::memory_order_relaxed);
+        T* spare = ready().load(std::memory_order_relaxed);
+        T* pub   = presented().load(std::memory_order_relaxed);
+        inprogress().store(spare, std::memory_order_relaxed);
+        ready().store(pub, std::memory_order_relaxed);
+        presented().store(just, std::memory_order_release);
+        m_pub_id.fetch_add(1, std::memory_order_release);
     }
-    T* getInprogress() { return inprogress(); }
+    T* getInprogress() { return inprogress().load(std::memory_order_relaxed); }
 
     virtual uint width() const  = 0;
     virtual uint height() const = 0;
@@ -32,8 +49,7 @@ protected:
     virtual std::atomic<T*>& inprogress() = 0;
 
 private:
-    std::atomic<bool>& dirty() { return m_dirty; };
-    std::atomic<bool>  m_dirty { false };
+    std::atomic<uint64_t> m_pub_id { 0 };
 };
 
 } // namespace wallpaper

--- a/src/backend_scene/src/Vulkan/CMakeLists.txt
+++ b/src/backend_scene/src/Vulkan/CMakeLists.txt
@@ -7,6 +7,7 @@ STATIC
 Instance.cpp
 Device.cpp
 SharedGpuContext.cpp
+MirrorRegistry.cpp
 GraphicsPipeline.cpp
 Shader.cpp
 StagingBuffer.cpp

--- a/src/backend_scene/src/Vulkan/CMakeLists.txt
+++ b/src/backend_scene/src/Vulkan/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${LIB_NAME}
 STATIC
 Instance.cpp
 Device.cpp
+SharedGpuContext.cpp
 GraphicsPipeline.cpp
 Shader.cpp
 StagingBuffer.cpp

--- a/src/backend_scene/src/Vulkan/Device.cpp
+++ b/src/backend_scene/src/Vulkan/Device.cpp
@@ -102,7 +102,6 @@ bool Device::Create(Instance& inst, std::span<const Extension> exts, VkExtent2D 
     device.dld      = vvk::DeviceDispatch { inst.inst().Dispatch() };
     device.m_gpu    = inst.gpu();
     device.m_limits = inst.gpu().GetProperties().limits;
-    device.set_out_extent(extent);
 
     Set<std::string> tested_exts;
     {
@@ -157,7 +156,7 @@ bool Device::Create(Instance& inst, std::span<const Extension> exts, VkExtent2D 
         allocatorInfo.instance               = *inst.inst();
         VVK_CHECK_BOOL_RE(vvk::CreateVmaAllocator(allocatorInfo, device.m_allocator));
     }
-    device.m_tex_cache = std::make_unique<TextureCache>(device);
+    device.m_asset_cache = std::make_unique<AssetCache>(device);
     return true;
 }
 
@@ -177,7 +176,7 @@ VkDeviceSize Device::GetUsage() const {
 
 void Device::Destroy() { VVK_CHECK(m_device.WaitIdle()); }
 
-Device::Device(): m_tex_cache(std::make_unique<TextureCache>(*this)) {}
+Device::Device(): m_asset_cache(std::make_unique<AssetCache>(*this)) {}
 Device::~Device() {};
 
 bool Device::supportExt(std::string_view name) const { return exists(m_extensions, name); }

--- a/src/backend_scene/src/Vulkan/Device.cpp
+++ b/src/backend_scene/src/Vulkan/Device.cpp
@@ -162,9 +162,17 @@ bool Device::Create(Instance& inst, std::span<const Extension> exts, VkExtent2D 
 }
 
 VkDeviceSize Device::GetUsage() const {
-    VmaBudget budget;
-    vmaGetHeapBudgets(*m_allocator, &budget);
-    return budget.usage;
+    // vmaGetHeapBudgets writes one VmaBudget per memory heap, so the destination
+    // must be sized for every heap or it overruns the buffer.
+    VmaBudget budgets[VK_MAX_MEMORY_HEAPS] {};
+    vmaGetHeapBudgets(*m_allocator, budgets);
+
+    const VkPhysicalDeviceMemoryProperties mem = m_gpu.GetMemoryProperties().memoryProperties;
+    VkDeviceSize                           usage { 0 };
+    for (uint32_t i = 0; i < mem.memoryHeapCount; i++) {
+        if (mem.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) usage += budgets[i].usage;
+    }
+    return usage;
 }
 
 void Device::Destroy() { VVK_CHECK(m_device.WaitIdle()); }

--- a/src/backend_scene/src/Vulkan/MirrorRegistry.cpp
+++ b/src/backend_scene/src/Vulkan/MirrorRegistry.cpp
@@ -1,0 +1,50 @@
+#include "Vulkan/MirrorRegistry.hpp"
+
+#include "Utils/Logging.h"
+
+namespace wallpaper
+{
+namespace vulkan
+{
+
+MirrorRegistry& MirrorRegistry::Instance() {
+    static MirrorRegistry s_instance;
+    return s_instance;
+}
+
+std::pair<MirrorRole, std::shared_ptr<MirrorSlot>> MirrorRegistry::acquire(const std::string& key,
+                                                                           ScreenToken token) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    auto                        it = m_slots.find(key);
+    if (it != m_slots.end() && it->second->primary_alive.load()) {
+        return { MirrorRole::Secondary, it->second };
+    }
+    auto slot           = std::make_shared<MirrorSlot>();
+    slot->primary       = token;
+    slot->primary_alive = true;
+    m_slots[key]        = slot;
+    LOG_INFO("mirror: screen %llu is primary for group %s", (unsigned long long)token, key.c_str());
+    return { MirrorRole::Primary, slot };
+}
+
+void MirrorRegistry::publish(const std::shared_ptr<MirrorSlot>& slot,
+                             std::shared_ptr<VulkanExSwapchain> sc) {
+    std::lock_guard<std::mutex> lk(slot->mtx);
+    slot->swapchain = std::move(sc);
+}
+
+void MirrorRegistry::release(const std::string& key, ScreenToken token) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    auto                        it = m_slots.find(key);
+    if (it == m_slots.end() || it->second->primary != token) return;
+    it->second->primary_alive.store(false);
+    {
+        std::lock_guard<std::mutex> slk(it->second->mtx);
+        it->second->swapchain.reset();
+    }
+    m_slots.erase(it);
+    LOG_INFO("mirror: primary %llu left group %s", (unsigned long long)token, key.c_str());
+}
+
+} // namespace vulkan
+} // namespace wallpaper

--- a/src/backend_scene/src/Vulkan/MirrorRegistry.cpp
+++ b/src/backend_scene/src/Vulkan/MirrorRegistry.cpp
@@ -28,9 +28,11 @@ std::pair<MirrorRole, std::shared_ptr<MirrorSlot>> MirrorRegistry::acquire(const
 }
 
 void MirrorRegistry::publish(const std::shared_ptr<MirrorSlot>& slot,
-                             std::shared_ptr<VulkanExSwapchain> sc) {
+                             std::shared_ptr<VulkanExSwapchain> sc,
+                             std::shared_ptr<SharedGpuContext>  gpu) {
     std::lock_guard<std::mutex> lk(slot->mtx);
     slot->swapchain = std::move(sc);
+    slot->gpu       = std::move(gpu);
 }
 
 void MirrorRegistry::release(const std::string& key, ScreenToken token) {

--- a/src/backend_scene/src/Vulkan/Parameters.cpp
+++ b/src/backend_scene/src/Vulkan/Parameters.cpp
@@ -1,5 +1,7 @@
 #include "Parameters.hpp"
 
+#include <unistd.h>
+
 namespace wallpaper
 {
 namespace vulkan
@@ -32,8 +34,10 @@ VmaImageParameters& VmaImageParameters::operator=(VmaImageParameters&& o) noexce
     return *this;
 }
 
-ExImageParameters::ExImageParameters()  = default;
-ExImageParameters::~ExImageParameters() = default;
+ExImageParameters::ExImageParameters() = default;
+ExImageParameters::~ExImageParameters() {
+    if (fd > 0) ::close(fd);
+}
 ExImageParameters::ExImageParameters(ExImageParameters&& o) noexcept
     : mem(std::move(o.mem)),
       mem_reqs(o.mem_reqs),

--- a/src/backend_scene/src/Vulkan/SharedGpuContext.cpp
+++ b/src/backend_scene/src/Vulkan/SharedGpuContext.cpp
@@ -1,0 +1,95 @@
+#include "SharedGpuContext.hpp"
+
+#include "Utils/Logging.h"
+#include "Core/MapSet.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+
+using namespace wallpaper::vulkan;
+
+namespace
+{
+std::string UuidHex(std::span<const std::uint8_t> uuid) {
+    std::string out;
+    out.reserve(uuid.size() * 2);
+    char buf[3];
+    for (auto b : uuid) {
+        std::snprintf(buf, sizeof(buf), "%02x", (unsigned)b);
+        out.append(buf, 2);
+    }
+    return out;
+}
+} // namespace
+
+SharedGpuContext::~SharedGpuContext() {
+    if (m_device_ready && m_device.handle()) {
+        VVK_CHECK(m_device.handle().WaitIdle());
+        m_device.Destroy();
+    }
+    m_instance.Destroy();
+}
+
+std::shared_ptr<SharedGpuContext> SharedGpuContext::Create(const GpuContextCreateInfo& ci) {
+    auto ctx = std::make_shared<SharedGpuContext>();
+
+    if (! Instance::Create(ctx->m_instance, ci.inst_exts, ci.inst_layers)) {
+        LOG_ERROR("init vulkan failed");
+        return nullptr;
+    }
+    if (ci.create_surface) {
+        VkSurfaceKHR surface;
+        VVK_CHECK_ACT(
+            {
+                LOG_ERROR("create vulkan surface failed");
+                return nullptr;
+            },
+            ci.create_surface(*ctx->m_instance.inst(), &surface));
+        ctx->m_instance.setSurface(VkSurfaceKHR(surface));
+    }
+    {
+        auto       surface     = *ctx->m_instance.surface();
+        auto       device_exts = ci.device_exts;
+        const auto check_gpu   = [device_exts, surface](const vvk::PhysicalDevice& gpu) {
+            return Device::CheckGPU(gpu, device_exts, surface);
+        };
+        if (! ctx->m_instance.ChoosePhysicalDevice(check_gpu, ci.uuid)) return nullptr;
+    }
+    if (! Device::Create(ctx->m_instance, ci.device_exts, ci.extent, ctx->m_device)) {
+        LOG_ERROR("init vulkan device failed");
+        return nullptr;
+    }
+    ctx->m_device_ready = true;
+    return ctx;
+}
+
+bool wallpaper::vulkan::GpuSharingEnabled() {
+    static const bool enabled = std::getenv("WP_SHARE_GPU") != nullptr;
+    return enabled;
+}
+
+std::shared_ptr<SharedGpuContext>
+wallpaper::vulkan::AcquireGpuContext(const GpuContextCreateInfo& ci) {
+    // Surface renderers (the standalone viewer) and the disabled path keep their
+    // own private context — never cached, so topology matches the unshared build.
+    if (! ci.offscreen || ! GpuSharingEnabled() || ci.uuid.empty()) {
+        return SharedGpuContext::Create(ci);
+    }
+
+    static std::mutex                                        mtx;
+    static Map<std::string, std::weak_ptr<SharedGpuContext>> cache;
+
+    std::lock_guard<std::mutex> lk(mtx);
+    const std::string           key = UuidHex(ci.uuid);
+    if (auto it = cache.find(key); it != cache.end()) {
+        if (auto sp = it->second.lock()) {
+            LOG_INFO("reuse shared gpu context for uuid %s", key.c_str());
+            return sp;
+        }
+    }
+    auto sp = SharedGpuContext::Create(ci);
+    if (sp) cache[key] = sp;
+    return sp;
+}

--- a/src/backend_scene/src/Vulkan/SharedGpuContext.cpp
+++ b/src/backend_scene/src/Vulkan/SharedGpuContext.cpp
@@ -65,16 +65,21 @@ std::shared_ptr<SharedGpuContext> SharedGpuContext::Create(const GpuContextCreat
     return ctx;
 }
 
-bool wallpaper::vulkan::GpuSharingEnabled() {
-    static const bool enabled = std::getenv("WP_SHARE_GPU") != nullptr;
-    return enabled;
+namespace
+{
+bool SharingEnabled(bool requested) {
+    // WP_SHARE_GPU overrides the per-screen setting: "0"/empty forces off,
+    // anything else forces on. Handy as a kill switch and for the viewer.
+    if (const char* e = std::getenv("WP_SHARE_GPU")) return e[0] != '0' && e[0] != '\0';
+    return requested;
 }
+} // namespace
 
 std::shared_ptr<SharedGpuContext>
 wallpaper::vulkan::AcquireGpuContext(const GpuContextCreateInfo& ci) {
     // Surface renderers (the standalone viewer) and the disabled path keep their
     // own private context — never cached, so topology matches the unshared build.
-    if (! ci.offscreen || ! GpuSharingEnabled() || ci.uuid.empty()) {
+    if (! ci.offscreen || ! SharingEnabled(ci.share_enabled) || ci.uuid.empty()) {
         return SharedGpuContext::Create(ci);
     }
 

--- a/src/backend_scene/src/Vulkan/TextureCache.cpp
+++ b/src/backend_scene/src/Vulkan/TextureCache.cpp
@@ -417,9 +417,33 @@ std::optional<ExImageParameters> TextureCache::CreateExTex(uint32_t width, uint3
     return opt;
 }
 
-ImageSlotsRef TextureCache::CreateTex(Image& image) {
+AssetCache::AssetCache(const Device& device): m_device(device) {}
+AssetCache::~AssetCache() {}
+
+void AssetCache::allocateCmd() {
+    const auto& pool = m_device.cmd_pool();
+    VVK_CHECK(pool.Allocate(1, VK_COMMAND_BUFFER_LEVEL_PRIMARY, m_tex_cmds));
+    m_tex_cmd = vvk::CommandBuffer(m_tex_cmds[0], m_device.handle().Dispatch());
+}
+
+void AssetCache::ReleaseScreen(ScreenToken who) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    for (auto it = m_tex_map.begin(); it != m_tex_map.end();) {
+        it->second.holders.erase(who);
+        if (it->second.holders.empty())
+            it = m_tex_map.erase(it);
+        else
+            ++it;
+    }
+}
+
+ImageSlotsRef AssetCache::CreateTexShared(Image& image, ScreenToken who) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+
     if (exists(m_tex_map, image.key)) {
-        return m_tex_map.at(image.key);
+        auto& entry = m_tex_map.at(image.key);
+        entry.holders.insert(who);
+        return entry.slots;
     }
 
     ImageSlots img_slots;
@@ -497,8 +521,10 @@ ImageSlotsRef TextureCache::CreateTex(Image& image) {
 
         m_device.handle().WaitIdle();
     }
-    m_tex_map[image.key] = std::move(img_slots);
-    return m_tex_map[image.key];
+    auto& entry = m_tex_map[image.key];
+    entry.slots = std::move(img_slots);
+    entry.holders.insert(who);
+    return entry.slots;
 }
 
 void TextureCache::allocateCmd() {
@@ -544,7 +570,6 @@ TextureCache::TextureCache(const Device& device): m_device(device) {}
 TextureCache::~TextureCache() {};
 
 void TextureCache::Clear() {
-    m_tex_map.clear();
     m_query_texs.clear();
     m_query_map.clear();
 }

--- a/src/backend_scene/src/Vulkan/TextureCache.cpp
+++ b/src/backend_scene/src/Vulkan/TextureCache.cpp
@@ -411,6 +411,7 @@ std::optional<ExImageParameters> TextureCache::CreateExTex(uint32_t width, uint3
         const auto& eximg = opt.value();
 
         if (! m_tex_cmd) allocateCmd();
+        std::lock_guard<std::mutex> lk(m_device.queue_mutex());
         TransImgLayout(m_device.graphics_queue().handle, m_tex_cmd, eximg, VK_IMAGE_LAYOUT_GENERAL);
         VVK_CHECK(m_device.handle().WaitIdle());
     }
@@ -510,16 +511,19 @@ ImageSlotsRef AssetCache::CreateTexShared(Image& image, ScreenToken who) {
             extents.push_back(VkExtent3D { (u32)image_data.width, (u32)image_data.height, 1 });
         }
 
-        CopyImageData(transform<VmaBufferParameters>(stage_bufs,
-                                                     [](BufferParameters e) {
-                                                         return e;
-                                                     }),
-                      extents,
-                      m_device.graphics_queue().handle,
-                      m_tex_cmd,
-                      image_paras);
+        {
+            std::lock_guard<std::mutex> lk(m_device.queue_mutex());
+            CopyImageData(transform<VmaBufferParameters>(stage_bufs,
+                                                         [](BufferParameters e) {
+                                                             return e;
+                                                         }),
+                          extents,
+                          m_device.graphics_queue().handle,
+                          m_tex_cmd,
+                          image_paras);
 
-        m_device.handle().WaitIdle();
+            m_device.handle().WaitIdle();
+        }
     }
     auto& entry = m_tex_map[image.key];
     entry.slots = std::move(img_slots);
@@ -528,8 +532,7 @@ ImageSlotsRef AssetCache::CreateTexShared(Image& image, ScreenToken who) {
 }
 
 void TextureCache::allocateCmd() {
-    const auto& pool = m_device.cmd_pool();
-    VVK_CHECK(pool.Allocate(1, VK_COMMAND_BUFFER_LEVEL_PRIMARY, m_tex_cmds));
+    VVK_CHECK(m_cmd_pool.Allocate(1, VK_COMMAND_BUFFER_LEVEL_PRIMARY, m_tex_cmds));
     m_tex_cmd = vvk::CommandBuffer(m_tex_cmds[0], m_device.handle().Dispatch());
 }
 
@@ -554,18 +557,21 @@ std::optional<VmaImageParameters> TextureCache::CreateTex(TextureKey tex_key) {
             break;
 
         if (! m_tex_cmd) allocateCmd();
-        TransImgLayout(m_device.graphics_queue().handle,
-                       m_tex_cmd,
-                       image_paras,
-                       VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-        VVK_CHECK_ACT(break, m_device.handle().WaitIdle());
+        {
+            std::lock_guard<std::mutex> lk(m_device.queue_mutex());
+            TransImgLayout(m_device.graphics_queue().handle,
+                           m_tex_cmd,
+                           image_paras,
+                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            VVK_CHECK_ACT(break, m_device.handle().WaitIdle());
+        }
         return image_paras;
     } while (false);
     return std::nullopt;
 }
 
-TextureCache::TextureCache(const Device& device): m_device(device) {}
+TextureCache::TextureCache(const Device& device, const vvk::CommandPool& cmd_pool)
+    : m_device(device), m_cmd_pool(cmd_pool) {}
 
 TextureCache::~TextureCache() {};
 

--- a/src/backend_scene/src/Vulkan/TextureCache.cpp
+++ b/src/backend_scene/src/Vulkan/TextureCache.cpp
@@ -438,11 +438,17 @@ void AssetCache::ReleaseScreen(ScreenToken who) {
     }
 }
 
-ImageSlotsRef AssetCache::CreateTexShared(Image& image, ScreenToken who) {
+ImageSlotsRef AssetCache::CreateTexShared(Image& image, ScreenToken who, std::string_view ns) {
     std::lock_guard<std::mutex> lk(m_mutex);
 
-    if (exists(m_tex_map, image.key)) {
-        auto& entry = m_tex_map.at(image.key);
+    // Namespace the cache key by the wallpaper identity: this cache is shared
+    // across screens on the same GPU, and image.key is only a per-package relative
+    // texture name, so two different wallpapers could otherwise collide on a same
+    // name and reuse each other's GPU image.
+    const std::string key = std::string(ns) + '|' + image.key;
+
+    if (exists(m_tex_map, key)) {
+        auto& entry = m_tex_map.at(key);
         entry.holders.insert(who);
         return entry.slots;
     }
@@ -525,7 +531,7 @@ ImageSlotsRef AssetCache::CreateTexShared(Image& image, ScreenToken who) {
             m_device.handle().WaitIdle();
         }
     }
-    auto& entry = m_tex_map[image.key];
+    auto& entry = m_tex_map[key];
     entry.slots = std::move(img_slots);
     entry.holders.insert(who);
     return entry.slots;

--- a/src/backend_scene/src/Vulkan/include/Vulkan/Device.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/Device.hpp
@@ -32,12 +32,10 @@ public:
     const auto& vma_allocator() const { return *m_allocator; }
     const auto& cmd_pool() const { return m_command_pool; }
     const auto& swapchain() const { return m_swapchain; }
-    const auto& out_extent() const { return m_extent; }
-    void        set_out_extent(VkExtent2D v) { m_extent = v; }
 
     bool supportExt(std::string_view) const;
 
-    TextureCache& tex_cache() const { return *m_tex_cache; }
+    AssetCache& asset_cache() const { return *m_asset_cache; }
 
     VkDeviceSize GetUsage() const;
 
@@ -59,10 +57,7 @@ private:
     QueueParameters m_graphics_queue;
     QueueParameters m_present_queue;
 
-    // output extent
-    VkExtent2D m_extent { 1, 1 };
-
-    std::unique_ptr<TextureCache> m_tex_cache;
+    std::unique_ptr<AssetCache> m_asset_cache;
 };
 
 } // namespace vulkan

--- a/src/backend_scene/src/Vulkan/include/Vulkan/Device.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/Device.hpp
@@ -5,6 +5,8 @@
 #include "Parameters.hpp"
 #include "TextureCache.hpp"
 
+#include <mutex>
+
 namespace wallpaper
 {
 namespace vulkan
@@ -37,6 +39,10 @@ public:
 
     AssetCache& asset_cache() const { return *m_asset_cache; }
 
+    // Serializes vkQueueSubmit/Present across the render threads that share this
+    // device. Uncontended when the device is not shared.
+    std::mutex& queue_mutex() const { return m_queue_mutex; }
+
     VkDeviceSize GetUsage() const;
 
 private:
@@ -58,6 +64,8 @@ private:
     QueueParameters m_present_queue;
 
     std::unique_ptr<AssetCache> m_asset_cache;
+
+    mutable std::mutex m_queue_mutex;
 };
 
 } // namespace vulkan

--- a/src/backend_scene/src/Vulkan/include/Vulkan/MirrorRegistry.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/MirrorRegistry.hpp
@@ -9,6 +9,7 @@
 
 #include "Core/MapSet.hpp"
 #include "Vulkan/VulkanExSwapchain.hpp"
+#include "Vulkan/SharedGpuContext.hpp"
 
 namespace wallpaper
 {
@@ -29,8 +30,12 @@ enum class MirrorRole
 struct MirrorSlot {
     std::mutex                         mtx;
     std::shared_ptr<VulkanExSwapchain> swapchain; // null until the primary publishes
-    ScreenToken                        primary { 0 };
-    std::atomic<bool>                  primary_alive { true };
+    // The primary's GPU context owns the swapchain images/memory. Held here so it
+    // outlives the primary renderer while a secondary still displays its frames
+    // (matters when GPU sharing is off and the primary has a private device).
+    std::shared_ptr<SharedGpuContext> gpu;
+    ScreenToken                       primary { 0 };
+    std::atomic<bool>                 primary_alive { true };
 };
 
 // Process-global registry of mirror groups keyed by a render-identity string
@@ -46,8 +51,9 @@ public:
     std::pair<MirrorRole, std::shared_ptr<MirrorSlot>> acquire(const std::string& key,
                                                                ScreenToken        token);
 
-    // Primary publishes its swapchain into the slot once it has been created.
-    void publish(const std::shared_ptr<MirrorSlot>& slot, std::shared_ptr<VulkanExSwapchain> sc);
+    // Primary publishes its swapchain (and the context owning it) into the slot.
+    void publish(const std::shared_ptr<MirrorSlot>& slot, std::shared_ptr<VulkanExSwapchain> sc,
+                 std::shared_ptr<SharedGpuContext> gpu);
 
     // Primary leaving (teardown or scene change): mark the group dead and drop the
     // key so surviving secondaries re-elect a new primary on their next tick.

--- a/src/backend_scene/src/Vulkan/include/Vulkan/MirrorRegistry.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/MirrorRegistry.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "Core/MapSet.hpp"
+#include "Vulkan/VulkanExSwapchain.hpp"
+
+namespace wallpaper
+{
+namespace vulkan
+{
+
+using ScreenToken = std::uint64_t;
+
+enum class MirrorRole
+{
+    Primary,
+    Secondary
+};
+
+// One mirror group: the primary renders into `swapchain`, secondaries import it.
+// Held through a shared_ptr by every member so it (and the swapchain) outlives the
+// primary's renderer until the last secondary drops it.
+struct MirrorSlot {
+    std::mutex                         mtx;
+    std::shared_ptr<VulkanExSwapchain> swapchain; // null until the primary publishes
+    ScreenToken                        primary { 0 };
+    std::atomic<bool>                  primary_alive { true };
+};
+
+// Process-global registry of mirror groups keyed by a render-identity string
+// (gpu uuid + scene + resolution + fillmode + speed + user props). Only built for
+// scenes that are not mouse-dependent, so a single rendered frame is correct on
+// every member screen.
+class MirrorRegistry {
+public:
+    static MirrorRegistry& Instance();
+
+    // Claims `key` for `token`. Becomes primary when the key is unclaimed or its
+    // previous primary has died; otherwise secondary. Always returns the shared slot.
+    std::pair<MirrorRole, std::shared_ptr<MirrorSlot>> acquire(const std::string& key,
+                                                               ScreenToken        token);
+
+    // Primary publishes its swapchain into the slot once it has been created.
+    void publish(const std::shared_ptr<MirrorSlot>& slot, std::shared_ptr<VulkanExSwapchain> sc);
+
+    // Primary leaving (teardown or scene change): mark the group dead and drop the
+    // key so surviving secondaries re-elect a new primary on their next tick.
+    void release(const std::string& key, ScreenToken token);
+
+private:
+    MirrorRegistry() = default;
+
+    std::mutex                                    m_mtx;
+    Map<std::string, std::shared_ptr<MirrorSlot>> m_slots;
+};
+
+} // namespace vulkan
+} // namespace wallpaper

--- a/src/backend_scene/src/Vulkan/include/Vulkan/SharedGpuContext.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/SharedGpuContext.hpp
@@ -17,6 +17,7 @@ struct GpuContextCreateInfo {
     VkExtent2D                     extent { 1, 1 };
     std::span<const std::uint8_t>  uuid;
     bool                           offscreen { true };
+    bool                           share_enabled { true };
     bool                           enable_valid_layer { false };
     // Creates a surface on the freshly built instance. Empty for offscreen.
     std::function<VkResult(VkInstance, VkSurfaceKHR*)> create_surface;
@@ -42,10 +43,9 @@ private:
     bool     m_device_ready { false };
 };
 
-bool GpuSharingEnabled();
-
 // Returns a shared context for the given GPU UUID when sharing is enabled and
-// the renderer is offscreen; otherwise returns a fresh, unshared context.
+// the renderer is offscreen; otherwise returns a fresh, unshared context. The
+// WP_SHARE_GPU env var overrides the request (set to 0 to force off).
 std::shared_ptr<SharedGpuContext> AcquireGpuContext(const GpuContextCreateInfo&);
 
 } // namespace vulkan

--- a/src/backend_scene/src/Vulkan/include/Vulkan/SharedGpuContext.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/SharedGpuContext.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include "Instance.hpp"
+#include "Device.hpp"
+
+#include <functional>
+#include <memory>
+
+namespace wallpaper
+{
+namespace vulkan
+{
+
+struct GpuContextCreateInfo {
+    std::span<const Extension>     inst_exts;
+    std::span<const InstanceLayer> inst_layers;
+    std::span<const Extension>     device_exts;
+    VkExtent2D                     extent { 1, 1 };
+    std::span<const std::uint8_t>  uuid;
+    bool                           offscreen { true };
+    bool                           enable_valid_layer { false };
+    // Creates a surface on the freshly built instance. Empty for offscreen.
+    std::function<VkResult(VkInstance, VkSurfaceKHR*)> create_surface;
+};
+
+// Owns a VkInstance + VkDevice (and its VMA allocator / asset cache). When GPU
+// sharing is enabled, every offscreen renderer on the same physical GPU shares
+// one instance. Held through a shared_ptr so the context tears down only after
+// the last screen releases it.
+class SharedGpuContext : NoCopy, NoMove {
+public:
+    SharedGpuContext() = default;
+    ~SharedGpuContext();
+
+    Instance& instance() { return m_instance; }
+    Device&   device() { return m_device; }
+
+    static std::shared_ptr<SharedGpuContext> Create(const GpuContextCreateInfo&);
+
+private:
+    Instance m_instance;
+    Device   m_device;
+    bool     m_device_ready { false };
+};
+
+bool GpuSharingEnabled();
+
+// Returns a shared context for the given GPU UUID when sharing is enabled and
+// the renderer is offscreen; otherwise returns a fresh, unshared context.
+std::shared_ptr<SharedGpuContext> AcquireGpuContext(const GpuContextCreateInfo&);
+
+} // namespace vulkan
+} // namespace wallpaper

--- a/src/backend_scene/src/Vulkan/include/Vulkan/TextureCache.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/TextureCache.hpp
@@ -47,7 +47,9 @@ struct TextureKey {
 // scale with resolution and are never shared between screens.
 class TextureCache : NoCopy, NoMove {
 public:
-    TextureCache(const Device&);
+    // cmd_pool is the per-screen command pool used for transient layout/copy
+    // commands, so screens sharing a device never touch the same pool.
+    TextureCache(const Device&, const vvk::CommandPool& cmd_pool);
     ~TextureCache();
 
     void Clear();
@@ -68,7 +70,8 @@ private:
     vvk::CommandBuffers               m_tex_cmds;
     vvk::CommandBuffer                m_tex_cmd;
 
-    const Device& m_device;
+    const Device&           m_device;
+    const vvk::CommandPool& m_cmd_pool;
 
     struct QueryTex {
         idx                index { 0 };

--- a/src/backend_scene/src/Vulkan/include/Vulkan/TextureCache.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/TextureCache.hpp
@@ -93,7 +93,7 @@ public:
     AssetCache(const Device&);
     ~AssetCache();
 
-    ImageSlotsRef CreateTexShared(Image&, ScreenToken);
+    ImageSlotsRef CreateTexShared(Image&, ScreenToken, std::string_view ns);
     void          ReleaseScreen(ScreenToken);
 
 private:

--- a/src/backend_scene/src/Vulkan/include/Vulkan/TextureCache.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/TextureCache.hpp
@@ -5,6 +5,9 @@
 #include "Core/NoCopyMove.hpp"
 #include "Core/MapSet.hpp"
 
+#include <cstdint>
+#include <mutex>
+
 namespace wallpaper
 {
 
@@ -12,6 +15,10 @@ class Image;
 
 namespace vulkan
 {
+
+// Stable id identifying the renderer (screen) that owns a reference to a shared
+// asset texture.
+using ScreenToken = std::uint64_t;
 
 VkFormat             ToVkType(TextureFormat);
 VkSamplerAddressMode ToVkType(TextureWrap);
@@ -36,6 +43,8 @@ struct TextureKey {
     static TexHash HashValue(const TextureKey&);
 };
 
+// Per-screen pool of render targets and external-memory swapchain images. These
+// scale with resolution and are never shared between screens.
 class TextureCache : NoCopy, NoMove {
 public:
     TextureCache(const Device&);
@@ -45,7 +54,6 @@ public:
 
     std::optional<ExImageParameters> CreateExTex(uint32_t witdh, uint32_t height, VkFormat,
                                                  VkImageTiling);
-    ImageSlotsRef                    CreateTex(Image&);
 
     std::optional<ImageParameters> Query(std::string_view key, TextureKey content_hash,
                                          bool persist = false);
@@ -60,8 +68,7 @@ private:
     vvk::CommandBuffers               m_tex_cmds;
     vvk::CommandBuffer                m_tex_cmd;
 
-    const Device&                m_device;
-    Map<std::string, ImageSlots> m_tex_map;
+    const Device& m_device;
 
     struct QueryTex {
         idx                index { 0 };
@@ -73,6 +80,32 @@ private:
     };
     std::vector<std::unique_ptr<QueryTex>> m_query_texs;
     Map<std::string, QueryTex*>            m_query_map;
+};
+
+// Process-wide (per shared Device) cache of decoded asset textures keyed by
+// image key. Reference-counted by screen so the textures survive as long as any
+// screen still references them — this is what dedupes VRAM across monitors.
+class AssetCache : NoCopy, NoMove {
+public:
+    AssetCache(const Device&);
+    ~AssetCache();
+
+    ImageSlotsRef CreateTexShared(Image&, ScreenToken);
+    void          ReleaseScreen(ScreenToken);
+
+private:
+    void allocateCmd();
+
+    const Device&       m_device;
+    std::mutex          m_mutex;
+    vvk::CommandBuffers m_tex_cmds;
+    vvk::CommandBuffer  m_tex_cmd;
+
+    struct Entry {
+        ImageSlots       slots;
+        Set<ScreenToken> holders;
+    };
+    Map<std::string, Entry> m_tex_map;
 };
 
 } // namespace vulkan

--- a/src/backend_scene/src/Vulkan/include/Vulkan/VulkanExSwapchain.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/VulkanExSwapchain.hpp
@@ -76,8 +76,7 @@ inline std::unique_ptr<VulkanExSwapchain> CreateExSwapchain(TextureCache& rt_poo
                                                             VkImageTiling tiling) {
     std::array<VulkanExHandle, 3> handles;
     for (auto& handle : handles) {
-        if (auto rv = rt_pool.CreateExTex(w, h, VK_FORMAT_R8G8B8A8_UNORM, tiling);
-            rv.has_value())
+        if (auto rv = rt_pool.CreateExTex(w, h, VK_FORMAT_R8G8B8A8_UNORM, tiling); rv.has_value())
             handle.image = std::move(rv.value());
         else
             return nullptr;

--- a/src/backend_scene/src/Vulkan/include/Vulkan/VulkanExSwapchain.hpp
+++ b/src/backend_scene/src/Vulkan/include/Vulkan/VulkanExSwapchain.hpp
@@ -72,11 +72,11 @@ private:
     VkExtent2D                    m_extent;
 };
 
-inline std::unique_ptr<VulkanExSwapchain> CreateExSwapchain(const Device& device, uint w, uint h,
+inline std::unique_ptr<VulkanExSwapchain> CreateExSwapchain(TextureCache& rt_pool, uint w, uint h,
                                                             VkImageTiling tiling) {
     std::array<VulkanExHandle, 3> handles;
     for (auto& handle : handles) {
-        if (auto rv = device.tex_cache().CreateExTex(w, h, VK_FORMAT_R8G8B8A8_UNORM, tiling);
+        if (auto rv = rt_pool.CreateExTex(w, h, VK_FORMAT_R8G8B8A8_UNORM, tiling);
             rv.has_value())
             handle.image = std::move(rv.value());
         else

--- a/src/backend_scene/src/VulkanRender/CopyPass.cpp
+++ b/src/backend_scene/src/VulkanRender/CopyPass.cpp
@@ -31,7 +31,7 @@ void CopyPass::prepare(Scene& scene, const Device& device, RenderingResources& r
         ImageParameters img;
         if (IsSpecTex(tex_name)) {
             auto& rt  = scene.renderTargets.at(tex_name);
-            auto  opt = device.tex_cache().Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
+            auto  opt = rr.rt_pool->Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
             if (opt.has_value())
                 img = opt.value();
             else
@@ -44,7 +44,7 @@ void CopyPass::prepare(Scene& scene, const Device& device, RenderingResources& r
     }
 
     for (auto& tex : releaseTexs()) {
-        device.tex_cache().MarkShareReady(tex);
+        rr.rt_pool->MarkShareReady(tex);
     }
 
     setPrepared();
@@ -149,7 +149,7 @@ void CopyPass::execute(const Device& device, RenderingResources& rr) {
     }
 
     if (dst.mipmap_level > 1) {
-        device.tex_cache().RecGenerateMipmaps(cmd, dst);
+        rr.rt_pool->RecGenerateMipmaps(cmd, dst);
     }
 };
 void CopyPass::destory(const Device&, RenderingResources&) {}

--- a/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
+++ b/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
@@ -139,12 +139,16 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
             return;
         }
 
-        // Check if shader uses time-based uniforms (for caching optimization)
-        if (! ref.blocks.empty()) {
-            auto& block          = ref.blocks.front();
-            m_uses_time_uniforms = exists(block.member_map, G_TIME) ||
-                                   exists(block.member_map, G_DAYTIME) ||
-                                   exists(block.member_map, G_POINTERPOSITION);
+        // Whether the shader reads any per-frame-varying uniform; such a pass must
+        // not be cached as frame-static. Covers time, cursor/parallax, and puppet
+        // bones (driven by frameTime). Check every uniform block, not just the first.
+        for (auto& block : ref.blocks) {
+            if (exists(block.member_map, G_TIME) || exists(block.member_map, G_DAYTIME) ||
+                exists(block.member_map, G_POINTERPOSITION) ||
+                exists(block.member_map, G_PARALLAXPOSITION) || exists(block.member_map, G_BONES)) {
+                m_uses_time_uniforms = true;
+                break;
+            }
         }
 
         auto& bindings = descriptor_info.bindings;

--- a/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
+++ b/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
@@ -117,7 +117,8 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
         } else {
             auto image = scene.imageParser->Parse(tex_name);
             if (image) {
-                img_slots = device.asset_cache().CreateTexShared(*image, rr.screen_token);
+                img_slots =
+                    device.asset_cache().CreateTexShared(*image, rr.screen_token, scene.scene_id);
             } else {
                 LOG_ERROR("parse tex \"%s\" failed", tex_name.c_str());
             }

--- a/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
+++ b/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
@@ -124,19 +124,8 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
         }
         m_desc.vk_textures[i] = img_slots;
     }
-    {
-        auto& tex_name = m_desc.output;
-        assert(IsSpecTex(tex_name));
-        assert(scene.renderTargets.count(tex_name) > 0);
-        auto& rt = scene.renderTargets.at(tex_name);
-        if (auto opt = device.tex_cache().Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
-            opt.has_value()) {
-            m_desc.vk_output = opt.value();
-        } else
-            return;
-    }
-
-    SceneMesh& mesh = *(m_desc.node->Mesh());
+    SceneMesh& mesh   = *(m_desc.node->Mesh());
+    m_desc.dyn_vertex = mesh.Dynamic();
 
     std::vector<Uni_ShaderSpv> spvs;
     DescriptorSetInfo          descriptor_info;
@@ -182,6 +171,44 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
                 binding = (i32)ref.binding_map.at(WE_GLTEX_NAMES[i]).binding;
             m_desc.vk_tex_binding.push_back(binding);
         }
+    }
+
+    // Static-pass caching: a pass may be executed once and skipped afterwards
+    // when its output never changes. That holds when the pass is static (no
+    // dynamic geometry/sprites), independent of time/pointer uniforms, reads
+    // only frame-static inputs, and writes a dedicated reusable effect buffer
+    // (not the shared canvas, which PrePass clears every frame). prepare() runs
+    // in topological order, so input producers are recorded before consumers.
+    {
+        bool inputs_static = true;
+        for (auto& in_name : m_desc.textures) {
+            if (in_name.empty()) continue;
+            if (IsSpecTex(in_name)) {
+                auto it = scene.rt_frame_static.find(in_name);
+                if (it == scene.rt_frame_static.end() || ! it->second) {
+                    inputs_static = false;
+                    break;
+                }
+            }
+        }
+        auto& out_rt   = scene.renderTargets.at(m_desc.output);
+        m_frame_static = scene.cache_passes && isStatic() && ! m_uses_time_uniforms &&
+                         inputs_static && out_rt.allowReuse;
+        scene.rt_frame_static[m_desc.output] = m_frame_static;
+    }
+
+    {
+        auto& tex_name = m_desc.output;
+        assert(IsSpecTex(tex_name));
+        assert(scene.renderTargets.count(tex_name) > 0);
+        auto& rt = scene.renderTargets.at(tex_name);
+        // pin the output when caching so the pooled texture is never recycled
+        // and keeps holding the cached result (in SHADER_READ_ONLY) across frames
+        bool persist = m_frame_static || ! rt.allowReuse;
+        if (auto opt = device.tex_cache().Query(tex_name, ToTexKey(rt), persist); opt.has_value()) {
+            m_desc.vk_output = opt.value();
+        } else
+            return;
     }
 
     m_desc.draw_count = 0;
@@ -397,9 +424,9 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
 }
 
 void CustomShaderPass::execute(const Device&, RenderingResources& rr) {
-    // NOTE: Pass caching disabled - output textures are not preserved between frames
-    // in current render graph implementation. Would need persistent render targets.
-    // if (isCacheable() && m_cached) { return; }
+    // Skip frame-static passes after their first execution: the output is pinned
+    // and already holds the result in SHADER_READ_ONLY for downstream passes.
+    if (m_frame_static && m_cached) return;
 
     if (m_desc.update_op) m_desc.update_op();
 
@@ -519,6 +546,8 @@ void CustomShaderPass::execute(const Device&, RenderingResources& rr) {
     }
 
     cmd.EndRenderPass();
+
+    if (m_frame_static) markCached();
 }
 
 void CustomShaderPass::destory(const Device&, RenderingResources& rr) {

--- a/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
+++ b/src/backend_scene/src/VulkanRender/CustomShaderPass.cpp
@@ -111,13 +111,13 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
         if (IsSpecTex(tex_name)) {
             if (scene.renderTargets.count(tex_name) == 0) continue;
             auto& rt  = scene.renderTargets.at(tex_name);
-            auto  opt = device.tex_cache().Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
+            auto  opt = rr.rt_pool->Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
             if (! opt.has_value()) continue;
             img_slots.slots = { opt.value() };
         } else {
             auto image = scene.imageParser->Parse(tex_name);
             if (image) {
-                img_slots = device.tex_cache().CreateTex(*image);
+                img_slots = device.asset_cache().CreateTexShared(*image, rr.screen_token);
             } else {
                 LOG_ERROR("parse tex \"%s\" failed", tex_name.c_str());
             }
@@ -205,7 +205,7 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
         // pin the output when caching so the pooled texture is never recycled
         // and keeps holding the cached result (in SHADER_READ_ONLY) across frames
         bool persist = m_frame_static || ! rt.allowReuse;
-        if (auto opt = device.tex_cache().Query(tex_name, ToTexKey(rt), persist); opt.has_value()) {
+        if (auto opt = rr.rt_pool->Query(tex_name, ToTexKey(rt), persist); opt.has_value()) {
             m_desc.vk_output = opt.value();
         } else
             return;
@@ -418,7 +418,7 @@ void CustomShaderPass::prepare(Scene& scene, const Device& device, RenderingReso
         };
     }
     for (auto& tex : releaseTexs()) {
-        device.tex_cache().MarkShareReady(tex);
+        rr.rt_pool->MarkShareReady(tex);
     }
     setPrepared();
 }

--- a/src/backend_scene/src/VulkanRender/CustomShaderPass.hpp
+++ b/src/backend_scene/src/VulkanRender/CustomShaderPass.hpp
@@ -75,6 +75,9 @@ private:
     Desc m_desc;
     bool m_cached { false };
     bool m_uses_time_uniforms { false };
+    // decided in prepare(): output never changes after the first frame, so
+    // execute() may be skipped on subsequent frames (graph-aware, see prepare)
+    bool m_frame_static { false };
 };
 
 } // namespace vulkan

--- a/src/backend_scene/src/VulkanRender/FinPass.cpp
+++ b/src/backend_scene/src/VulkanRender/FinPass.cpp
@@ -96,7 +96,7 @@ void FinPass::prepare(Scene& scene, const Device& device, RenderingResources& rr
         auto tex_name = std::string(m_desc.result);
         if (scene.renderTargets.count(tex_name) == 0) return;
         auto& rt = scene.renderTargets.at(tex_name);
-        if (auto opt = device.tex_cache().Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
+        if (auto opt = rr.rt_pool->Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
             opt.has_value()) {
             m_desc.vk_result = opt.value();
         }

--- a/src/backend_scene/src/VulkanRender/PrePass.cpp
+++ b/src/backend_scene/src/VulkanRender/PrePass.cpp
@@ -20,12 +20,12 @@ TextureKey ToTexKey(wallpaper::SceneRenderTarget rt) {
 }
 } // namespace
 
-void PrePass::prepare(Scene& scene, const Device& device, RenderingResources&) {
+void PrePass::prepare(Scene& scene, const Device& device, RenderingResources& rr) {
     {
         auto tex_name = std::string(m_desc.result);
         if (scene.renderTargets.count(tex_name) == 0) return;
         auto& rt = scene.renderTargets.at(tex_name);
-        if (auto opt = device.tex_cache().Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
+        if (auto opt = rr.rt_pool->Query(tex_name, ToTexKey(rt), ! rt.allowReuse);
             opt.has_value()) {
             m_desc.vk_result = opt.value();
         } else

--- a/src/backend_scene/src/VulkanRender/Resource.hpp
+++ b/src/backend_scene/src/VulkanRender/Resource.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "Core/NoCopyMove.hpp"
 #include "Vulkan/StagingBuffer.hpp"
+#include "Vulkan/TextureCache.hpp"
 #include <memory>
 
 namespace wallpaper
@@ -17,6 +18,10 @@ struct RenderingResources {
 
     StagingBuffer* vertex_buf;
     StagingBuffer* dyn_buf;
+
+    // Per-screen render-target pool and this screen's asset-cache token.
+    TextureCache* rt_pool { nullptr };
+    ScreenToken   screen_token { 0 };
 };
 } // namespace vulkan
 } // namespace wallpaper

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -75,7 +75,8 @@ struct VulkanRender::Impl {
     Instance& instance() { return m_gpu->instance(); }
     Device&   device() { return m_gpu->device(); }
 
-    // Per-screen render-target pool, output extent and asset-cache token.
+    // Per-screen command pool, render-target pool, output extent and token.
+    vvk::CommandPool              m_cmd_pool;
     std::unique_ptr<TextureCache> m_rt_pool;
     VkExtent2D                    m_out_extent { 1, 1 };
     ScreenToken                   m_token { 0 };
@@ -174,7 +175,17 @@ bool VulkanRender::Impl::init(RenderInitInfo info) {
     static std::atomic<ScreenToken> s_next_token { 1 };
     m_token      = s_next_token++;
     m_out_extent = extent;
-    m_rt_pool    = std::make_unique<TextureCache>(device());
+
+    {
+        VkCommandPoolCreateInfo pool_info {
+            .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+            .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT |
+                     VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+            .queueFamilyIndex = device().graphics_queue().family_index,
+        };
+        VVK_CHECK_BOOL_RE(device().handle().CreateCommandPool(pool_info, m_cmd_pool));
+    }
+    m_rt_pool = std::make_unique<TextureCache>(device(), m_cmd_pool);
 
     if (info.offscreen) {
         m_ex_swapchain = CreateExSwapchain(*m_rt_pool,
@@ -226,7 +237,7 @@ bool VulkanRender::Impl::initRes() {
     if (! m_vertex_buf->allocate()) return false;
     if (! m_dyn_buf->allocate()) return false;
     {
-        auto& pool = device().cmd_pool();
+        auto& pool = m_cmd_pool;
         VVK_CHECK_BOOL_RE(pool.Allocate(vk_command_num, VK_COMMAND_BUFFER_LEVEL_PRIMARY, m_cmds));
         m_upload_cmd = vvk::CommandBuffer(m_cmds[0], device().handle().Dispatch());
         m_render_cmd = vvk::CommandBuffer(m_cmds[1], device().handle().Dispatch());
@@ -368,7 +379,6 @@ void VulkanRender::Impl::drawFrameSwapchain() {
                 .pSignalSemaphores    = rr.sem_swap_finish.address(),
     };
 
-    VVK_CHECK_VOID_RE(device().present_queue().handle.Submit(sub_info, *rr.fence_frame));
     VkPresentInfoKHR present_info {
         .sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
         .pNext              = nullptr,
@@ -378,7 +388,11 @@ void VulkanRender::Impl::drawFrameSwapchain() {
         .pSwapchains        = device().swapchain().handle().address(),
         .pImageIndices      = &image_index,
     };
-    VVK_CHECK_VOID_RE(device().present_queue().handle.Present(present_info));
+    {
+        std::lock_guard<std::mutex> lk(device().queue_mutex());
+        VVK_CHECK_VOID_RE(device().present_queue().handle.Submit(sub_info, *rr.fence_frame));
+        VVK_CHECK_VOID_RE(device().present_queue().handle.Present(present_info));
+    }
 
     VVK_CHECK_VOID_RE(rr.fence_frame.Wait(vk_wait_time));
     VVK_CHECK_VOID_RE(rr.fence_frame.Reset());
@@ -410,7 +424,10 @@ void VulkanRender::Impl::drawFrameOffscreen() {
         .commandBufferCount = 1,
         .pCommandBuffers    = rr.command.address(),
     };
-    VVK_CHECK_VOID_RE(device().graphics_queue().handle.Submit(sub_info, *rr.fence_frame));
+    {
+        std::lock_guard<std::mutex> lk(device().queue_mutex());
+        VVK_CHECK_VOID_RE(device().graphics_queue().handle.Submit(sub_info, *rr.fence_frame));
+    }
 
     VVK_CHECK_VOID_RE(rr.fence_frame.Wait(vk_wait_time));
     VVK_CHECK_VOID_RE(rr.fence_frame.Reset());
@@ -583,7 +600,10 @@ void VulkanRender::Impl::compileRenderGraph(Scene& scene, rg::RenderGraph& rg) {
             .commandBufferCount = 1,
             .pCommandBuffers    = m_upload_cmd.address(),
         };
-        VVK_CHECK_VOID_RE(device().graphics_queue().handle.Submit(sub_info, *upload_fence));
+        {
+            std::lock_guard<std::mutex> lk(device().queue_mutex());
+            VVK_CHECK_VOID_RE(device().graphics_queue().handle.Submit(sub_info, *upload_fence));
+        }
         VVK_CHECK_VOID_RE(upload_fence.Wait(vk_wait_time));
     }
     m_pass_loaded = true;

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -289,7 +289,11 @@ void VulkanRender::Impl::DestroyRenderingResource(RenderingResources& rr) {}
 void VulkanRender::Impl::drawFrame(Scene& scene) {
     if (! (m_inited && m_pass_loaded)) return;
 
-        // LOG_INFO("used ram: %fm", (m_device->GetUsage()/1024.0f)/1024.0f);
+    if (std::getenv("WP_VMA_LOG")) {
+        static int s_vma_frame = 0;
+        if ((s_vma_frame++ % 120) == 0)
+            LOG_INFO("VMA device-local usage: %.1f MiB", (m_device->GetUsage() / 1024.0) / 1024.0);
+    }
 
 #if ENABLE_RENDERDOC_API
     if (rdoc_api)

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -162,6 +162,7 @@ bool VulkanRender::Impl::init(RenderInitInfo info) {
         .extent             = extent,
         .uuid               = info.uuid,
         .offscreen          = info.offscreen,
+        .share_enabled      = info.share_gpu,
         .enable_valid_layer = info.enable_valid_layer,
     };
     if (! info.offscreen) ci.create_surface = info.surface_info.createSurfaceOp;

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -76,9 +76,10 @@ struct VulkanRender::Impl {
     bool mirrorLost() const {
         return m_mirror && m_mirror_slot && ! m_mirror_slot->primary_alive.load();
     }
-    void releaseMirror();
-    void ensureSwapchain();
-    void bindMirrorSource();
+    void                                    releaseMirror();
+    void                                    ensureSwapchain();
+    void                                    bindMirrorSource();
+    std::shared_ptr<wallpaper::ExSwapchain> currentSwapchain();
 
     void invokeRedraw() {
         std::lock_guard<std::mutex> lk(m_redraw_mtx);
@@ -128,6 +129,9 @@ struct VulkanRender::Impl {
     std::string                        m_mirror_key;
     std::shared_ptr<MirrorSlot>        m_mirror_slot;
     std::shared_ptr<VulkanExSwapchain> m_mirror_source;
+    // Guards m_mirror / m_mirror_source / m_ex_swapchain against the QML consumer
+    // thread reading them via currentSwapchain() while the render thread re-elects.
+    std::mutex m_mirror_mtx;
 
     std::vector<VulkanPass*> m_passes;
 };
@@ -157,6 +161,10 @@ void VulkanRender::releaseMirror() { pImpl->releaseMirror(); }
 wallpaper::ExSwapchain* VulkanRender::exSwapchain() const {
     return pImpl->m_mirror ? pImpl->m_mirror_source.get() : pImpl->m_ex_swapchain.get();
 };
+
+std::shared_ptr<wallpaper::ExSwapchain> VulkanRender::currentSwapchain() const {
+    return pImpl->currentSwapchain();
+}
 
 bool VulkanRender::Impl::init(RenderInitInfo info) {
     if (m_inited) return true;
@@ -565,21 +573,32 @@ void VulkanRender::Impl::UpdateCameraFillMode(wallpaper::Scene&   scene,
 
 void VulkanRender::Impl::ensureSwapchain() {
     if (m_ex_swapchain || m_with_surface) return;
-    m_ex_swapchain =
-        CreateExSwapchain(*m_rt_pool, m_out_extent.width, m_out_extent.height, m_ex_tiling);
-    if (! m_ex_swapchain) LOG_ERROR("failed to create ex-swapchain");
+    auto sc = CreateExSwapchain(*m_rt_pool, m_out_extent.width, m_out_extent.height, m_ex_tiling);
+    if (! sc) LOG_ERROR("failed to create ex-swapchain");
+    std::lock_guard<std::mutex> lk(m_mirror_mtx);
+    m_ex_swapchain = std::move(sc);
 }
 
 void VulkanRender::Impl::bindMirrorSource() {
     if (! m_mirror_slot) return;
-    std::lock_guard<std::mutex> lk(m_mirror_slot->mtx);
+    std::lock_guard<std::mutex> lk(m_mirror_mtx);
+    std::lock_guard<std::mutex> slk(m_mirror_slot->mtx);
     m_mirror_source = m_mirror_slot->swapchain;
+}
+
+// Snapshot the live frame source as a shared_ptr so the QML consumer keeps it (and
+// its memory) alive across exSwapchain()/eatFrame(), even if the render thread
+// re-elects and resets the mirror source meanwhile.
+std::shared_ptr<wallpaper::ExSwapchain> VulkanRender::Impl::currentSwapchain() {
+    std::lock_guard<std::mutex> lk(m_mirror_mtx);
+    return m_mirror ? m_mirror_source : m_ex_swapchain;
 }
 
 bool VulkanRender::Impl::beginFrameSource(const std::string& key) {
     m_mirror_key = key;
     if (key.empty()) {
         ensureSwapchain();
+        std::lock_guard<std::mutex> lk(m_mirror_mtx);
         m_mirror = false;
         return true;
     }
@@ -588,16 +607,20 @@ bool VulkanRender::Impl::beginFrameSource(const std::string& key) {
     m_mirror_slot     = slot;
     if (role == MirrorRole::Primary) {
         ensureSwapchain();
-        MirrorRegistry::Instance().publish(slot, m_ex_swapchain);
+        MirrorRegistry::Instance().publish(slot, m_ex_swapchain, m_gpu);
+        std::lock_guard<std::mutex> lk(m_mirror_mtx);
         m_mirror = false;
         return true;
     }
 
     // Secondary: drop the graph we built only to learn mouse-dependency, free our
     // own swapchain if any, and display the primary's frames instead.
-    m_mirror = true;
     clearLastRenderGraph();
-    m_ex_swapchain.reset();
+    {
+        std::lock_guard<std::mutex> lk(m_mirror_mtx);
+        m_mirror = true;
+        m_ex_swapchain.reset();
+    }
     bindMirrorSource();
     LOG_INFO("mirror: screen %llu mirrors group %s", (unsigned long long)m_token, key.c_str());
     return false;
@@ -608,9 +631,12 @@ void VulkanRender::Impl::releaseMirror() {
     if (! m_mirror && ! m_mirror_key.empty()) {
         MirrorRegistry::Instance().release(m_mirror_key, m_token);
     }
-    m_mirror = false;
+    {
+        std::lock_guard<std::mutex> lk(m_mirror_mtx);
+        m_mirror = false;
+        m_mirror_source.reset();
+    }
     m_mirror_slot.reset();
-    m_mirror_source.reset();
     m_mirror_key.clear();
 }
 

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -11,6 +11,7 @@
 #include <glslang/Public/ShaderLang.h>
 
 #include "Vulkan/Device.hpp"
+#include "Vulkan/SharedGpuContext.hpp"
 #include "Vulkan/TextureCache.hpp"
 #include "Vulkan/Swapchain.hpp"
 #include "Vulkan/VulkanExSwapchain.hpp"
@@ -68,8 +69,10 @@ struct VulkanRender::Impl {
     void drawFrameOffscreen();
     void setRenderTargetSize(Scene&, rg::RenderGraph&);
 
-    Instance                m_instance;
-    std::unique_ptr<Device> m_device;
+    std::shared_ptr<SharedGpuContext> m_gpu;
+
+    Instance& instance() { return m_gpu->instance(); }
+    Device&   device() { return m_gpu->device(); }
 
     std::unique_ptr<PrePass> m_prepass { nullptr };
     std::unique_ptr<FinPass> m_finpass { nullptr };
@@ -143,39 +146,27 @@ bool VulkanRender::Impl::init(RenderInitInfo info) {
         LOG_INFO("vulkan valid layer \"%s\" enabled", VALIDATION_LAYER_NAME.data());
     }
 
-    if (! Instance::Create(m_instance, inst_exts, inst_layers)) {
-        LOG_ERROR("init vulkan failed");
-        return false;
-    }
-    if (! info.offscreen) {
-        VkSurfaceKHR surface;
-        VVK_CHECK_ACT(
-            {
-                LOG_ERROR("create vulkan surface failed");
-                return false;
-            },
-            info.surface_info.createSurfaceOp(*m_instance.inst(), &surface));
-        m_instance.setSurface(VkSurfaceKHR(surface));
-        m_with_surface = true;
-    }
-    {
-        auto surface   = *m_instance.surface();
-        auto check_gpu = [&device_exts, surface](const vvk::PhysicalDevice& gpu) {
-            return Device::CheckGPU(gpu, device_exts, surface);
-        };
-        if (! m_instance.ChoosePhysicalDevice(check_gpu, info.uuid)) return false;
-    }
+    m_with_surface = ! info.offscreen;
 
-    {
-        m_device = std::make_unique<Device>();
-        if (! Device::Create(m_instance, device_exts, extent, *m_device)) {
-            LOG_ERROR("init vulkan device failed");
-            return false;
-        }
+    GpuContextCreateInfo ci {
+        .inst_exts          = inst_exts,
+        .inst_layers        = inst_layers,
+        .device_exts        = device_exts,
+        .extent             = extent,
+        .uuid               = info.uuid,
+        .offscreen          = info.offscreen,
+        .enable_valid_layer = info.enable_valid_layer,
+    };
+    if (! info.offscreen) ci.create_surface = info.surface_info.createSurfaceOp;
+
+    m_gpu = AcquireGpuContext(ci);
+    if (! m_gpu) {
+        LOG_ERROR("init vulkan gpu context failed");
+        return false;
     }
 
     if (info.offscreen) {
-        m_ex_swapchain = CreateExSwapchain(*m_device,
+        m_ex_swapchain = CreateExSwapchain(device(),
                                            extent.width,
                                            extent.height,
                                            (info.offscreen_tiling == TexTiling::OPTIMAL
@@ -197,8 +188,8 @@ bool VulkanRender::Impl::initRes() {
     m_prepass = std::make_unique<PrePass>(PrePass::Desc {});
     m_finpass = std::make_unique<FinPass>(FinPass::Desc {});
     if (m_with_surface) {
-        m_finpass->setPresentFormat(m_device->swapchain().format());
-        m_finpass->setPresentQueueIndex(m_device->present_queue().family_index);
+        m_finpass->setPresentFormat(device().swapchain().format());
+        m_finpass->setPresentQueueIndex(device().present_queue().family_index);
         m_finpass->setPresentLayout(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
     } else {
         m_finpass->setPresentFormat(m_ex_swapchain->format());
@@ -208,15 +199,15 @@ bool VulkanRender::Impl::initRes() {
     /*
     m_testpass = std::make_unique<FinPass>(FinPass::Desc{});
     m_testpass->setPresentFormat(m_ex_swapchain->format());
-    m_testpass->setPresentQueueIndex(m_device->graphics_queue().family_index);
+    m_testpass->setPresentQueueIndex(device().graphics_queue().family_index);
     m_testpass->setPresentLayout(vk::ImageLayout::ePresentSrcKHR);
     */
 
-    m_vertex_buf = std::make_unique<StagingBuffer>(*m_device,
+    m_vertex_buf = std::make_unique<StagingBuffer>(device(),
                                                    2 * 1024 * 1024,
                                                    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
                                                        VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
-    m_dyn_buf    = std::make_unique<StagingBuffer>(*m_device,
+    m_dyn_buf    = std::make_unique<StagingBuffer>(device(),
                                                 2 * 1024 * 1024,
                                                 VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
                                                     VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
@@ -224,10 +215,10 @@ bool VulkanRender::Impl::initRes() {
     if (! m_vertex_buf->allocate()) return false;
     if (! m_dyn_buf->allocate()) return false;
     {
-        auto& pool = m_device->cmd_pool();
+        auto& pool = device().cmd_pool();
         VVK_CHECK_BOOL_RE(pool.Allocate(vk_command_num, VK_COMMAND_BUFFER_LEVEL_PRIMARY, m_cmds));
-        m_upload_cmd = vvk::CommandBuffer(m_cmds[0], m_device->handle().Dispatch());
-        m_render_cmd = vvk::CommandBuffer(m_cmds[1], m_device->handle().Dispatch());
+        m_upload_cmd = vvk::CommandBuffer(m_cmds[0], device().handle().Dispatch());
+        m_render_cmd = vvk::CommandBuffer(m_cmds[1], device().handle().Dispatch());
     }
     if (! CreateRenderingResource(m_rendering_resources)) return false;
 
@@ -243,24 +234,24 @@ void VulkanRender::Impl::destroy() {
     // Finalize glslang (paired with InitializeProcess in init)
     glslang::FinalizeProcess();
 
-    if (m_device && m_device->handle()) {
-        VVK_CHECK(m_device->handle().WaitIdle());
+    if (m_gpu && device().handle()) {
+        VVK_CHECK(device().handle().WaitIdle());
 
         // res
         for (auto& p : m_passes) {
-            p->destory(*m_device, m_rendering_resources);
+            p->destory(device(), m_rendering_resources);
         }
         m_vertex_buf->destroy();
         m_dyn_buf->destroy();
-
-        m_device->Destroy();
     }
-    m_instance.Destroy();
+    // Release this screen's hold on the shared context; the instance/device tear
+    // down once the last screen drops it.
+    m_gpu.reset();
 }
 
 bool VulkanRender::Impl::CreateRenderingResource(RenderingResources& rr) {
     rr.command = m_render_cmd;
-    VVK_CHECK_BOOL_RE(m_device->handle().CreateFence(
+    VVK_CHECK_BOOL_RE(device().handle().CreateFence(
         VkFenceCreateInfo {
             .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
             .pNext = nullptr,
@@ -273,8 +264,8 @@ bool VulkanRender::Impl::CreateRenderingResource(RenderingResources& rr) {
     if (m_with_surface) {
         VkSemaphoreCreateInfo ci { .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
                                    .pNext = nullptr };
-        VVK_CHECK_BOOL_RE(m_device->handle().CreateSemaphore(ci, rr.sem_swap_finish));
-        VVK_CHECK_BOOL_RE(m_device->handle().CreateSemaphore(ci, rr.sem_swap_wait_image));
+        VVK_CHECK_BOOL_RE(device().handle().CreateSemaphore(ci, rr.sem_swap_finish));
+        VVK_CHECK_BOOL_RE(device().handle().CreateSemaphore(ci, rr.sem_swap_wait_image));
     }
 
     rr.vertex_buf = m_vertex_buf.get();
@@ -292,16 +283,16 @@ void VulkanRender::Impl::drawFrame(Scene& scene) {
     if (std::getenv("WP_VMA_LOG")) {
         static int s_vma_frame = 0;
         if ((s_vma_frame++ % 120) == 0)
-            LOG_INFO("VMA device-local usage: %.1f MiB", (m_device->GetUsage() / 1024.0) / 1024.0);
+            LOG_INFO("VMA device-local usage: %.1f MiB", (device().GetUsage() / 1024.0) / 1024.0);
     }
 
 #if ENABLE_RENDERDOC_API
     if (rdoc_api)
         rdoc_api->StartFrameCapture(
-            RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE((VkInstance)m_instance.inst()), NULL);
+            RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE((VkInstance)instance().inst()), NULL);
 #endif
 
-    if (m_instance.offscreen()) {
+    if (instance().offscreen()) {
         drawFrameOffscreen();
     } else {
         drawFrameSwapchain();
@@ -312,7 +303,7 @@ void VulkanRender::Impl::drawFrame(Scene& scene) {
 #if ENABLE_RENDERDOC_API
     if (rdoc_api)
         rdoc_api->EndFrameCapture(
-            RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE((VkInstance)m_instance.inst()), NULL);
+            RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE((VkInstance)instance().inst()), NULL);
 #endif
 }
 
@@ -323,13 +314,13 @@ void VulkanRender::Impl::drawFrameSwapchain() {
     resource_index         = (resource_index + 1) % 3;
     uint32_t image_index   = 0;
     {
-        VVK_CHECK_VOID_RE(m_device->handle().AcquireNextImageKHR(*m_device->swapchain().handle(),
-                                                                 vk_wait_time,
-                                                                 *rr.sem_swap_wait_image,
-                                                                 {},
-                                                                 &image_index));
+        VVK_CHECK_VOID_RE(device().handle().AcquireNextImageKHR(*device().swapchain().handle(),
+                                                                vk_wait_time,
+                                                                *rr.sem_swap_wait_image,
+                                                                {},
+                                                                &image_index));
     }
-    const auto& image = m_device->swapchain().images()[image_index];
+    const auto& image = device().swapchain().images()[image_index];
 
     m_finpass->setPresent(image);
 
@@ -341,7 +332,7 @@ void VulkanRender::Impl::drawFrameSwapchain() {
     m_dyn_buf->recordUpload(rr.command);
     for (auto* p : m_passes) {
         if (p->prepared()) {
-            p->execute(*m_device, rr);
+            p->execute(device(), rr);
         }
     }
     (void)rr.command.End();
@@ -359,17 +350,17 @@ void VulkanRender::Impl::drawFrameSwapchain() {
                 .pSignalSemaphores    = rr.sem_swap_finish.address(),
     };
 
-    VVK_CHECK_VOID_RE(m_device->present_queue().handle.Submit(sub_info, *rr.fence_frame));
+    VVK_CHECK_VOID_RE(device().present_queue().handle.Submit(sub_info, *rr.fence_frame));
     VkPresentInfoKHR present_info {
         .sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
         .pNext              = nullptr,
         .waitSemaphoreCount = 1,
         .pWaitSemaphores    = rr.sem_swap_finish.address(),
         .swapchainCount     = 1,
-        .pSwapchains        = m_device->swapchain().handle().address(),
+        .pSwapchains        = device().swapchain().handle().address(),
         .pImageIndices      = &image_index,
     };
-    VVK_CHECK_VOID_RE(m_device->present_queue().handle.Present(present_info));
+    VVK_CHECK_VOID_RE(device().present_queue().handle.Present(present_info));
 
     VVK_CHECK_VOID_RE(rr.fence_frame.Wait(vk_wait_time));
     VVK_CHECK_VOID_RE(rr.fence_frame.Reset());
@@ -389,7 +380,7 @@ void VulkanRender::Impl::drawFrameOffscreen() {
 
     for (auto* p : m_passes) {
         if (p->prepared()) {
-            p->execute(*m_device, rr);
+            p->execute(device(), rr);
         }
     }
 
@@ -401,7 +392,7 @@ void VulkanRender::Impl::drawFrameOffscreen() {
         .commandBufferCount = 1,
         .pCommandBuffers    = rr.command.address(),
     };
-    VVK_CHECK_VOID_RE(m_device->graphics_queue().handle.Submit(sub_info, *rr.fence_frame));
+    VVK_CHECK_VOID_RE(device().graphics_queue().handle.Submit(sub_info, *rr.fence_frame));
 
     VVK_CHECK_VOID_RE(rr.fence_frame.Wait(vk_wait_time));
     VVK_CHECK_VOID_RE(rr.fence_frame.Reset());
@@ -409,7 +400,7 @@ void VulkanRender::Impl::drawFrameOffscreen() {
 }
 
 void VulkanRender::Impl::setRenderTargetSize(Scene& scene, rg::RenderGraph& rg) {
-    auto& ext = m_device->out_extent();
+    auto& ext = device().out_extent();
     for (auto& item : scene.renderTargets) {
         auto& rt = item.second;
         if (rt.bind.enable && rt.bind.screen) {
@@ -445,8 +436,8 @@ void VulkanRender::Impl::setRenderTargetSize(Scene& scene, rg::RenderGraph& rg) 
 void VulkanRender::Impl::UpdateCameraFillMode(wallpaper::Scene&   scene,
                                               wallpaper::FillMode fillmode) {
     using namespace wallpaper;
-    auto width  = m_device->out_extent().width;
-    auto height = m_device->out_extent().height;
+    auto width  = device().out_extent().width;
+    auto height = device().out_extent().height;
 
     if (width == 0) return;
     double sw = scene.ortho[0], sh = scene.ortho[1];
@@ -494,10 +485,10 @@ void VulkanRender::Impl::UpdateCameraFillMode(wallpaper::Scene&   scene,
 
 void VulkanRender::Impl::clearLastRenderGraph() {
     for (auto& p : m_passes) {
-        p->destory(*m_device, m_rendering_resources);
+        p->destory(device(), m_rendering_resources);
     }
     m_passes.clear();
-    m_device->tex_cache().Clear();
+    device().tex_cache().Clear();
 
     m_vertex_buf->destroy();
     m_dyn_buf->destroy();
@@ -543,7 +534,7 @@ void VulkanRender::Impl::compileRenderGraph(Scene& scene, rg::RenderGraph& rg) {
 
     for (auto* p : m_passes) {
         if (! p->prepared()) {
-            p->prepare(scene, *m_device, m_rendering_resources);
+            p->prepare(scene, device(), m_rendering_resources);
         }
     }
 
@@ -557,7 +548,7 @@ void VulkanRender::Impl::compileRenderGraph(Scene& scene, rg::RenderGraph& rg) {
     {
         // Use fence instead of WaitIdle for better performance
         vvk::Fence upload_fence;
-        VVK_CHECK_VOID_RE(m_device->handle().CreateFence(
+        VVK_CHECK_VOID_RE(device().handle().CreateFence(
             VkFenceCreateInfo {
                 .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
                 .pNext = nullptr,
@@ -571,7 +562,7 @@ void VulkanRender::Impl::compileRenderGraph(Scene& scene, rg::RenderGraph& rg) {
             .commandBufferCount = 1,
             .pCommandBuffers    = m_upload_cmd.address(),
         };
-        VVK_CHECK_VOID_RE(m_device->graphics_queue().handle.Submit(sub_info, *upload_fence));
+        VVK_CHECK_VOID_RE(device().graphics_queue().handle.Submit(sub_info, *upload_fence));
         VVK_CHECK_VOID_RE(upload_fence.Wait(vk_wait_time));
     }
     m_pass_loaded = true;

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -7,6 +7,7 @@
 
 #include "Utils/Algorism.h"
 
+#include <cstdlib>
 #include <glslang/Public/ShaderLang.h>
 
 #include "Vulkan/Device.hpp"
@@ -504,6 +505,10 @@ void VulkanRender::Impl::clearLastRenderGraph() {
 void VulkanRender::Impl::compileRenderGraph(Scene& scene, rg::RenderGraph& rg) {
     if (! m_inited) return;
     m_pass_loaded = false;
+
+    // static-pass caching is recomputed per graph build; env var force-disables it
+    scene.rt_frame_static.clear();
+    if (std::getenv("WP_NO_PASS_CACHE") != nullptr) scene.cache_passes = false;
 
     auto nodes             = rg.topologicalOrder();
     auto node_release_texs = rg.getLastReadTexs(nodes);

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <vector>
 #include <cstdint>
+#include <atomic>
 
 #if ENABLE_RENDERDOC_API
 #    include "RenderDoc.h"
@@ -73,6 +74,11 @@ struct VulkanRender::Impl {
 
     Instance& instance() { return m_gpu->instance(); }
     Device&   device() { return m_gpu->device(); }
+
+    // Per-screen render-target pool, output extent and asset-cache token.
+    std::unique_ptr<TextureCache> m_rt_pool;
+    VkExtent2D                    m_out_extent { 1, 1 };
+    ScreenToken                   m_token { 0 };
 
     std::unique_ptr<PrePass> m_prepass { nullptr };
     std::unique_ptr<FinPass> m_finpass { nullptr };
@@ -165,8 +171,13 @@ bool VulkanRender::Impl::init(RenderInitInfo info) {
         return false;
     }
 
+    static std::atomic<ScreenToken> s_next_token { 1 };
+    m_token      = s_next_token++;
+    m_out_extent = extent;
+    m_rt_pool    = std::make_unique<TextureCache>(device());
+
     if (info.offscreen) {
-        m_ex_swapchain = CreateExSwapchain(device(),
+        m_ex_swapchain = CreateExSwapchain(*m_rt_pool,
                                            extent.width,
                                            extent.height,
                                            (info.offscreen_tiling == TexTiling::OPTIMAL
@@ -243,10 +254,15 @@ void VulkanRender::Impl::destroy() {
         }
         m_vertex_buf->destroy();
         m_dyn_buf->destroy();
+
+        // Free this screen's GPU resources while the (possibly shared) device is
+        // still alive, then drop the asset references it held.
+        m_ex_swapchain.reset();
+        m_rt_pool.reset();
+        device().asset_cache().ReleaseScreen(m_token);
     }
-    // Release this screen's hold on the shared context; the instance/device tear
-    // down once the last screen drops it.
-    m_gpu.reset();
+    // The shared context tears the instance/device down once the last screen
+    // releases it; member destruction order keeps m_gpu alive until then.
 }
 
 bool VulkanRender::Impl::CreateRenderingResource(RenderingResources& rr) {
@@ -268,8 +284,10 @@ bool VulkanRender::Impl::CreateRenderingResource(RenderingResources& rr) {
         VVK_CHECK_BOOL_RE(device().handle().CreateSemaphore(ci, rr.sem_swap_wait_image));
     }
 
-    rr.vertex_buf = m_vertex_buf.get();
-    rr.dyn_buf    = m_dyn_buf.get();
+    rr.vertex_buf   = m_vertex_buf.get();
+    rr.dyn_buf      = m_dyn_buf.get();
+    rr.rt_pool      = m_rt_pool.get();
+    rr.screen_token = m_token;
     return true;
 }
 
@@ -400,7 +418,7 @@ void VulkanRender::Impl::drawFrameOffscreen() {
 }
 
 void VulkanRender::Impl::setRenderTargetSize(Scene& scene, rg::RenderGraph& rg) {
-    auto& ext = device().out_extent();
+    auto& ext = m_out_extent;
     for (auto& item : scene.renderTargets) {
         auto& rt = item.second;
         if (rt.bind.enable && rt.bind.screen) {
@@ -436,8 +454,8 @@ void VulkanRender::Impl::setRenderTargetSize(Scene& scene, rg::RenderGraph& rg) 
 void VulkanRender::Impl::UpdateCameraFillMode(wallpaper::Scene&   scene,
                                               wallpaper::FillMode fillmode) {
     using namespace wallpaper;
-    auto width  = device().out_extent().width;
-    auto height = device().out_extent().height;
+    auto width  = m_out_extent.width;
+    auto height = m_out_extent.height;
 
     if (width == 0) return;
     double sw = scene.ortho[0], sh = scene.ortho[1];
@@ -488,7 +506,10 @@ void VulkanRender::Impl::clearLastRenderGraph() {
         p->destory(device(), m_rendering_resources);
     }
     m_passes.clear();
-    device().tex_cache().Clear();
+    // Drop only this screen's render targets and asset references; textures that
+    // other screens still hold survive.
+    m_rt_pool->Clear();
+    device().asset_cache().ReleaseScreen(m_token);
 
     m_vertex_buf->destroy();
     m_dyn_buf->destroy();

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -299,7 +299,12 @@ void VulkanRender::Impl::destroy() {
     glslang::FinalizeProcess();
 
     if (m_gpu && device().handle()) {
-        VVK_CHECK(device().handle().WaitIdle());
+        // vkDeviceWaitIdle needs external sync against all queue users; on a shared
+        // device another screen may still be submitting, so take the same mutex.
+        {
+            std::lock_guard<std::mutex> lk(device().queue_mutex());
+            VVK_CHECK(device().handle().WaitIdle());
+        }
 
         // If we were a mirror primary, release the group so secondaries re-elect.
         releaseMirror();

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -12,6 +12,7 @@
 
 #include "Vulkan/Device.hpp"
 #include "Vulkan/SharedGpuContext.hpp"
+#include "Vulkan/MirrorRegistry.hpp"
 #include "Vulkan/TextureCache.hpp"
 #include "Vulkan/Swapchain.hpp"
 #include "Vulkan/VulkanExSwapchain.hpp"
@@ -70,6 +71,15 @@ struct VulkanRender::Impl {
     void drawFrameOffscreen();
     void setRenderTargetSize(Scene&, rg::RenderGraph&);
 
+    bool beginFrameSource(const std::string& key);
+    bool isMirror() const { return m_mirror; }
+    bool mirrorLost() const {
+        return m_mirror && m_mirror_slot && ! m_mirror_slot->primary_alive.load();
+    }
+    void releaseMirror();
+    void ensureSwapchain();
+    void bindMirrorSource();
+
     std::shared_ptr<SharedGpuContext> m_gpu;
 
     Instance& instance() { return m_gpu->instance(); }
@@ -98,8 +108,16 @@ struct VulkanRender::Impl {
     bool m_inited { false };
     bool m_pass_loaded { false };
 
-    std::unique_ptr<VulkanExSwapchain> m_ex_swapchain;
+    VkImageTiling                      m_ex_tiling { VK_IMAGE_TILING_OPTIMAL };
+    std::shared_ptr<VulkanExSwapchain> m_ex_swapchain;
     RenderingResources                 m_rendering_resources;
+
+    // Mirror state: a secondary screen does not render; it displays the primary's
+    // swapchain (m_mirror_source) shared through m_mirror_slot.
+    bool                               m_mirror { false };
+    std::string                        m_mirror_key;
+    std::shared_ptr<MirrorSlot>        m_mirror_slot;
+    std::shared_ptr<VulkanExSwapchain> m_mirror_source;
 
     std::vector<VulkanPass*> m_passes;
 };
@@ -120,7 +138,14 @@ void VulkanRender::UpdateCameraFillMode(Scene& scene, wallpaper::FillMode fill) 
     pImpl->UpdateCameraFillMode(scene, fill);
 };
 
-wallpaper::ExSwapchain* VulkanRender::exSwapchain() const { return pImpl->m_ex_swapchain.get(); };
+bool VulkanRender::beginFrameSource(const std::string& key) { return pImpl->beginFrameSource(key); }
+bool VulkanRender::isMirror() const { return pImpl->isMirror(); }
+bool VulkanRender::mirrorLost() const { return pImpl->mirrorLost(); }
+void VulkanRender::releaseMirror() { pImpl->releaseMirror(); }
+
+wallpaper::ExSwapchain* VulkanRender::exSwapchain() const {
+    return pImpl->m_mirror ? pImpl->m_mirror_source.get() : pImpl->m_ex_swapchain.get();
+};
 
 bool VulkanRender::Impl::init(RenderInitInfo info) {
     if (m_inited) return true;
@@ -188,15 +213,10 @@ bool VulkanRender::Impl::init(RenderInitInfo info) {
     }
     m_rt_pool = std::make_unique<TextureCache>(device(), m_cmd_pool);
 
-    if (info.offscreen) {
-        m_ex_swapchain = CreateExSwapchain(*m_rt_pool,
-                                           extent.width,
-                                           extent.height,
-                                           (info.offscreen_tiling == TexTiling::OPTIMAL
-                                                ? VK_IMAGE_TILING_OPTIMAL
-                                                : VK_IMAGE_TILING_LINEAR));
-        m_with_surface = false;
-    }
+    // The offscreen swapchain is created lazily in beginFrameSource(): a screen
+    // that ends up mirroring another never allocates one.
+    m_ex_tiling = (info.offscreen_tiling == TexTiling::OPTIMAL ? VK_IMAGE_TILING_OPTIMAL
+                                                               : VK_IMAGE_TILING_LINEAR);
 
     if (! initRes()) return false;
 
@@ -215,7 +235,9 @@ bool VulkanRender::Impl::initRes() {
         m_finpass->setPresentQueueIndex(device().present_queue().family_index);
         m_finpass->setPresentLayout(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
     } else {
-        m_finpass->setPresentFormat(m_ex_swapchain->format());
+        // Offscreen present params are fixed (see VulkanExSwapchain::format); the
+        // swapchain itself may not exist yet when mirroring.
+        m_finpass->setPresentFormat(VK_FORMAT_R8G8B8A8_UNORM);
         m_finpass->setPresentLayout(VK_IMAGE_LAYOUT_GENERAL);
         m_finpass->setPresentQueueIndex(VK_QUEUE_FAMILY_EXTERNAL);
     }
@@ -260,6 +282,9 @@ void VulkanRender::Impl::destroy() {
     if (m_gpu && device().handle()) {
         VVK_CHECK(device().handle().WaitIdle());
 
+        // If we were a mirror primary, release the group so secondaries re-elect.
+        releaseMirror();
+
         // res
         for (auto& p : m_passes) {
             p->destory(device(), m_rendering_resources);
@@ -268,7 +293,8 @@ void VulkanRender::Impl::destroy() {
         m_dyn_buf->destroy();
 
         // Free this screen's GPU resources while the (possibly shared) device is
-        // still alive, then drop the asset references it held.
+        // still alive, then drop the asset references it held. A secondary still
+        // holding our swapchain keeps it alive via shared_ptr.
         m_ex_swapchain.reset();
         m_rt_pool.reset();
         device().asset_cache().ReleaseScreen(m_token);
@@ -308,6 +334,13 @@ void VulkanRender::Impl::DestroyRenderingResource(RenderingResources& rr) {}
 // VulkanExSwapchain* VulkanRender::exSwapchain() const { return m_ex_swapchain.get(); }
 
 void VulkanRender::Impl::drawFrame(Scene& scene) {
+    if (m_mirror) {
+        // Secondary: don't render. Bind the primary's swapchain when ready and ask
+        // the QML side to repaint so it picks up newly published frames.
+        if (! m_mirror_source) bindMirrorSource();
+        if (m_redraw_cb) m_redraw_cb();
+        return;
+    }
     if (! (m_inited && m_pass_loaded)) return;
 
     if (std::getenv("WP_VMA_LOG")) {
@@ -517,6 +550,57 @@ void VulkanRender::Impl::UpdateCameraFillMode(wallpaper::Scene&   scene,
     gCam.Update();
     gPerCam.Update();
     scene.UpdateLinkedCamera("global");
+}
+
+void VulkanRender::Impl::ensureSwapchain() {
+    if (m_ex_swapchain || m_with_surface) return;
+    m_ex_swapchain =
+        CreateExSwapchain(*m_rt_pool, m_out_extent.width, m_out_extent.height, m_ex_tiling);
+    if (! m_ex_swapchain) LOG_ERROR("failed to create ex-swapchain");
+}
+
+void VulkanRender::Impl::bindMirrorSource() {
+    if (! m_mirror_slot) return;
+    std::lock_guard<std::mutex> lk(m_mirror_slot->mtx);
+    m_mirror_source = m_mirror_slot->swapchain;
+}
+
+bool VulkanRender::Impl::beginFrameSource(const std::string& key) {
+    m_mirror_key = key;
+    if (key.empty()) {
+        ensureSwapchain();
+        m_mirror = false;
+        return true;
+    }
+
+    auto [role, slot] = MirrorRegistry::Instance().acquire(key, m_token);
+    m_mirror_slot     = slot;
+    if (role == MirrorRole::Primary) {
+        ensureSwapchain();
+        MirrorRegistry::Instance().publish(slot, m_ex_swapchain);
+        m_mirror = false;
+        return true;
+    }
+
+    // Secondary: drop the graph we built only to learn mouse-dependency, free our
+    // own swapchain if any, and display the primary's frames instead.
+    m_mirror = true;
+    clearLastRenderGraph();
+    m_ex_swapchain.reset();
+    bindMirrorSource();
+    LOG_INFO("mirror: screen %llu mirrors group %s", (unsigned long long)m_token, key.c_str());
+    return false;
+}
+
+void VulkanRender::Impl::releaseMirror() {
+    // Only a primary (rendered, non-empty key) owns the group registration.
+    if (! m_mirror && ! m_mirror_key.empty()) {
+        MirrorRegistry::Instance().release(m_mirror_key, m_token);
+    }
+    m_mirror = false;
+    m_mirror_slot.reset();
+    m_mirror_source.reset();
+    m_mirror_key.clear();
 }
 
 void VulkanRender::Impl::clearLastRenderGraph() {

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -80,6 +80,15 @@ struct VulkanRender::Impl {
     void ensureSwapchain();
     void bindMirrorSource();
 
+    void invokeRedraw() {
+        std::lock_guard<std::mutex> lk(m_redraw_mtx);
+        if (m_redraw_cb) m_redraw_cb();
+    }
+    void clearRedraw() {
+        std::lock_guard<std::mutex> lk(m_redraw_mtx);
+        m_redraw_cb = nullptr;
+    }
+
     std::shared_ptr<SharedGpuContext> m_gpu;
 
     Instance& instance() { return m_gpu->instance(); }
@@ -96,6 +105,7 @@ struct VulkanRender::Impl {
 
     std::unique_ptr<FinPass> m_testpass { nullptr };
     ReDrawCB                 m_redraw_cb;
+    std::mutex               m_redraw_mtx;
 
     std::unique_ptr<StagingBuffer> m_vertex_buf { nullptr };
     std::unique_ptr<StagingBuffer> m_dyn_buf { nullptr };
@@ -138,6 +148,7 @@ void VulkanRender::UpdateCameraFillMode(Scene& scene, wallpaper::FillMode fill) 
     pImpl->UpdateCameraFillMode(scene, fill);
 };
 
+void VulkanRender::clearRedrawCallback() { pImpl->clearRedraw(); }
 bool VulkanRender::beginFrameSource(const std::string& key) { return pImpl->beginFrameSource(key); }
 bool VulkanRender::isMirror() const { return pImpl->isMirror(); }
 bool VulkanRender::mirrorLost() const { return pImpl->mirrorLost(); }
@@ -338,7 +349,7 @@ void VulkanRender::Impl::drawFrame(Scene& scene) {
         // Secondary: don't render. Bind the primary's swapchain when ready and ask
         // the QML side to repaint so it picks up newly published frames.
         if (! m_mirror_source) bindMirrorSource();
-        if (m_redraw_cb) m_redraw_cb();
+        invokeRedraw();
         return;
     }
     if (! (m_inited && m_pass_loaded)) return;
@@ -361,7 +372,7 @@ void VulkanRender::Impl::drawFrame(Scene& scene) {
         drawFrameSwapchain();
     }
 
-    if (m_redraw_cb) m_redraw_cb();
+    invokeRedraw();
 
 #if ENABLE_RENDERDOC_API
     if (rdoc_api)

--- a/src/backend_scene/src/VulkanRender/include/VulkanRender/VulkanRender.hpp
+++ b/src/backend_scene/src/VulkanRender/include/VulkanRender/VulkanRender.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <memory>
+#include <string>
 
 namespace wallpaper
 {
@@ -30,6 +31,19 @@ public:
     void clearLastRenderGraph();
     void compileRenderGraph(Scene&, rg::RenderGraph&);
     void UpdateCameraFillMode(Scene&, wallpaper::FillMode);
+
+    // Decides this screen's frame source after the graph has been compiled. An
+    // empty key renders independently. A non-empty key joins a mirror group: the
+    // first screen becomes primary (renders + publishes its swapchain), later
+    // screens become secondary (their just-built graph is freed, they display the
+    // primary's frames). Returns true when this screen renders, false when it
+    // mirrors.
+    bool beginFrameSource(const std::string& mirror_key);
+    bool isMirror() const;
+    // True for a secondary whose primary has gone away; the caller should rebuild
+    // and re-run beginFrameSource to re-elect.
+    bool mirrorLost() const;
+    void releaseMirror();
 
     ExSwapchain* exSwapchain() const;
     bool         inited() const;

--- a/src/backend_scene/src/VulkanRender/include/VulkanRender/VulkanRender.hpp
+++ b/src/backend_scene/src/VulkanRender/include/VulkanRender/VulkanRender.hpp
@@ -46,7 +46,11 @@ public:
     void releaseMirror();
 
     ExSwapchain* exSwapchain() const;
-    bool         inited() const;
+    // Thread-safe shared_ptr snapshot of the live frame source (own or mirrored);
+    // the consumer should hold this across eatFrame() to avoid a use-after-free if
+    // the render thread re-elects mid-frame.
+    std::shared_ptr<ExSwapchain> currentSwapchain() const;
+    bool                         inited() const;
 
     // Synchronously stops the per-frame redraw callback from firing again. Called
     // from the QML render thread when the texture node is destroyed, so the render

--- a/src/backend_scene/src/VulkanRender/include/VulkanRender/VulkanRender.hpp
+++ b/src/backend_scene/src/VulkanRender/include/VulkanRender/VulkanRender.hpp
@@ -48,6 +48,11 @@ public:
     ExSwapchain* exSwapchain() const;
     bool         inited() const;
 
+    // Synchronously stops the per-frame redraw callback from firing again. Called
+    // from the QML render thread when the texture node is destroyed, so the render
+    // loop never emits into a half-destroyed node during teardown.
+    void clearRedrawCallback();
+
 private:
     struct Impl;
     std::unique_ptr<Impl> pImpl;

--- a/src/backend_scene/src/WPMdlParser.cpp
+++ b/src/backend_scene/src/WPMdlParser.cpp
@@ -43,8 +43,8 @@ bool WPMdlParser::Parse(std::string_view path, fs::VFS& vfs, WPMdl& mdl) {
     auto str_path = std::string(path);
     auto pfile    = vfs.Open("/assets/" + str_path);
     if (! pfile) return false;
-    auto memfile  = fs::MemBinaryStream(*pfile);
-    auto& f = memfile;
+    auto  memfile = fs::MemBinaryStream(*pfile);
+    auto& f       = memfile;
 
     mdl.mdlv = ReadMDLVesion(f);
 

--- a/src/backend_scene/src/WPSceneParser.cpp
+++ b/src/backend_scene/src/WPSceneParser.cpp
@@ -150,16 +150,19 @@ ParticleAnimationMode ToAnimMode(const std::string& str) {
     }
 }
 
-void LoadControlPoint(ParticleSubSystem& pSys, const wpscene::Particle& wp) {
-    std::span<ParticleControlpoint> pcs = pSys.Controlpoints();
-    usize                           s   = std::min(pcs.size(), wp.controlpoints.size());
+bool LoadControlPoint(ParticleSubSystem& pSys, const wpscene::Particle& wp) {
+    std::span<ParticleControlpoint> pcs            = pSys.Controlpoints();
+    usize                           s              = std::min(pcs.size(), wp.controlpoints.size());
+    bool                            any_link_mouse = false;
     for (usize i = 0; i < s; i++) {
         pcs[i].offset = Eigen::Vector3d { array_cast<double>(wp.controlpoints[i].offset).data() };
         pcs[i].link_mouse =
             wp.controlpoints[i].flags[wpscene::ParticleControlpoint::FlagEnum::link_mouse];
         pcs[i].worldspace =
             wp.controlpoints[i].flags[wpscene::ParticleControlpoint::FlagEnum::worldspace];
+        any_link_mouse = any_link_mouse || pcs[i].link_mouse;
     }
+    return any_link_mouse;
 }
 void LoadInitializer(ParticleSubSystem& pSys, const wpscene::Particle& wp,
                      const wpscene::ParticleInstanceoverride& over) {
@@ -1077,7 +1080,8 @@ void ParseParticleObj(ParseContext& context, wpscene::WPParticleObject& wppartob
     LoadEmitter(*particleSub, particle_obj, override.count, render_rope);
     LoadInitializer(*particleSub, particle_obj, override);
     LoadOperator(*particleSub, particle_obj, override);
-    LoadControlPoint(*particleSub, particle_obj);
+    if (LoadControlPoint(*particleSub, particle_obj))
+        context.shader_updater->SetParticleMouseLinked(true);
 
     mesh.AddMaterial(std::move(material));
     spNode->AddMesh(spMesh);

--- a/src/backend_scene/src/WPShaderValueUpdater.cpp
+++ b/src/backend_scene/src/WPShaderValueUpdater.cpp
@@ -68,10 +68,11 @@ void WPShaderValueUpdater::InitUniforms(SceneNode* pNode, const ExistsUniformOp&
     info.has_DAYTIME          = existsOp(G_DAYTIME);
     info.has_POINTERPOSITION  = existsOp(G_POINTERPOSITION);
     info.has_PARALLAXPOSITION = existsOp(G_PARALLAXPOSITION);
-    info.has_TEXELSIZE        = existsOp(G_TEXELSIZE);
-    info.has_TEXELSIZEHALF    = existsOp(G_TEXELSIZEHALF);
-    info.has_SCREEN           = existsOp(G_SCREEN);
-    info.has_LP               = existsOp(G_LP);
+    if (info.has_POINTERPOSITION || info.has_PARALLAXPOSITION) m_pointer_uniform_used = true;
+    info.has_TEXELSIZE     = existsOp(G_TEXELSIZE);
+    info.has_TEXELSIZEHALF = existsOp(G_TEXELSIZEHALF);
+    info.has_SCREEN        = existsOp(G_SCREEN);
+    info.has_LP            = existsOp(G_LP);
 
     std::accumulate(begin(info.texs), end(info.texs), 0, [&existsOp](uint index, auto& value) {
         value.has_resolution = existsOp(WE_GLTEX_RESOLUTION_NAMES[index]);

--- a/src/backend_scene/src/WPShaderValueUpdater.hpp
+++ b/src/backend_scene/src/WPShaderValueUpdater.hpp
@@ -79,6 +79,15 @@ public:
 
     void SetScreenSize(i32 w, i32 h) override { m_screen_size = { (float)w, (float)h }; }
 
+    void SetParticleMouseLinked(bool v) { m_particle_mouse_linked = v; }
+
+    // True when the rendered frame depends on cursor position (parallax, pointer
+    // uniforms, or mouse-linked particles), which differs per screen. Such scenes
+    // cannot be mirrored across monitors.
+    bool MouseDependent() const {
+        return m_parallax.enable || m_pointer_uniform_used || m_particle_mouse_linked;
+    }
+
     // Get interpolated mouse position in normalized coordinates (0-1)
     std::array<float, 2> GetMousePosition() const { return m_mousePos; }
 
@@ -87,6 +96,9 @@ private:
     WPCameraParallax     m_parallax;
     double               m_dayTime { 0.0f };
     std::array<float, 2> m_texelSize { 1.0f / 1920.0f, 1.0f / 1080.0f };
+
+    bool m_pointer_uniform_used { false };
+    bool m_particle_mouse_linked { false };
 
     std::array<float, 2> m_mousePos { 0.5f, 0.5f };
     std::array<float, 2> m_mousePosInput { 0.5f, 0.5f };

--- a/src/backend_scene/src/WPTexImageParser.cpp
+++ b/src/backend_scene/src/WPTexImageParser.cpp
@@ -111,7 +111,9 @@ void LoadHeader(fs::IBinaryStream& file, ImageHeader& header) {
 
     header.count = file.ReadInt32();
 
-    if (header.extraHeader["texb"].val == 3) header.type = static_cast<ImageType>(file.ReadInt32());
+    if (header.extraHeader["texb"].val >= 3) header.type = static_cast<ImageType>(file.ReadInt32());
+    // TEXB0004 stores an additional int field after the image format
+    if (header.extraHeader["texb"].val >= 4) file.ReadInt32();
 }
 
 void SetHeaderPow2(ImageHeader& header, i32 mip_0_w, i32 mip_0_h) {
@@ -170,14 +172,26 @@ std::shared_ptr<Image> WPTexImageParser::Parse(const std::string& name) {
     auto&                  img     = *img_ptr;
     img.key                        = name;
     auto pfile                     = m_vfs->Open(path);
-    if (! pfile) return nullptr;
+    if (! pfile) {
+        LOG_ERROR("open tex \"%s\" failed", path.c_str());
+        return nullptr;
+    }
     auto& file     = *pfile;
     auto  startpos = file.Tell();
     LoadHeader(file, img.header);
 
     // image
     i32 _image_count = img.header.count;
-    if (_image_count < 0) return nullptr;
+    if (_image_count < 0) {
+        LOG_ERROR("invalid tex \"%s\": count=%d texv=%d texi=%d texb=%d (header layout "
+                  "unsupported?)",
+                  name.c_str(),
+                  _image_count,
+                  (int)img.header.extraHeader["texv"].val,
+                  (int)img.header.extraHeader["texi"].val,
+                  (int)img.header.extraHeader["texb"].val);
+        return nullptr;
+    }
     usize image_count = (usize)_image_count;
 
     img.slots.resize(image_count);
@@ -207,8 +221,19 @@ std::shared_ptr<Image> WPTexImageParser::Parse(const std::string& name) {
             }
 
             i32 src_size = file.ReadInt32();
-            if (src_size <= 0 || mipmap.width <= 0 || mipmap.height <= 0 || decompressed_size < 0)
+            if (src_size <= 0 || mipmap.width <= 0 || mipmap.height <= 0 || decompressed_size < 0) {
+                LOG_ERROR("invalid tex \"%s\" mipmap %zu/%zu: width=%d height=%d src_size=%d "
+                          "decompressed_size=%d texb=%d",
+                          name.c_str(),
+                          i_mipmap,
+                          i_image,
+                          mipmap.width,
+                          mipmap.height,
+                          src_size,
+                          decompressed_size,
+                          (int)img.header.extraHeader["texb"].val);
                 return nullptr;
+            }
 
             char* result;
             result = new char[(usize)src_size];
@@ -228,10 +253,17 @@ std::shared_ptr<Image> WPTexImageParser::Parse(const std::string& name) {
                 }
             }
             // is image container
-            if (img.header.extraHeader["texb"].val == 3 && img.header.type != ImageType::UNKNOWN) {
+            if (img.header.extraHeader["texb"].val >= 3 && img.header.type != ImageType::UNKNOWN) {
                 int32_t w, h, n;
                 auto*   data =
                     stbi_load_from_memory((const unsigned char*)result, src_size, &w, &h, &n, 4);
+                if (data == nullptr) {
+                    LOG_ERROR("decode image container of tex \"%s\" failed: %s",
+                              name.c_str(),
+                              stbi_failure_reason());
+                    delete[] result;
+                    return nullptr;
+                }
                 mipmap.data = ImageDataPtr((uint8_t*)data, [](uint8_t* data) {
                     stbi_image_free((unsigned char*)data);
                 });

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -8,6 +8,8 @@
 #include "PluginInfo.hpp"
 #include "FileHelper.hpp"
 #include "GamemodeMonitor.hpp"
+#include "WallpaperSyncBus.hpp"
+#include "GlobalConfigStore.hpp"
 
 constexpr std::array<uint, 2> WPVer { 1, 2 };
 
@@ -26,6 +28,8 @@ public:
         qmlRegisterType<wekde::TTYSwitchMonitor>(uri, WPVer[0], WPVer[1], "TTYSwitchMonitor");
         qmlRegisterType<wekde::FileHelper>(uri, WPVer[0], WPVer[1], "FileHelper");
         qmlRegisterType<wekde::GamemodeMonitor>(uri, WPVer[0], WPVer[1], "GamemodeMonitor");
+        qmlRegisterType<wekde::WallpaperSyncBus>(uri, WPVer[0], WPVer[1], "WallpaperSyncBus");
+        qmlRegisterType<wekde::GlobalConfig>(uri, WPVer[0], WPVer[1], "GlobalConfig");
     }
 };
 


### PR DESCRIPTION
Branches off `main` and bundles the recent scene-renderer work. Lint is green (merged the null-deref fix from #16 and re-formatted `WPMdlParser.cpp`).

## Fixes
- **Closes #15** — scene wallpapers that use the `TEXB0004` texture container rendered only effects/particles, the background layer was missing (`parse tex failed`). `WPTexImageParser::LoadHeader` only read the image-format field for `texb==3`; `TEXB0004` stores the format plus an extra int, so every subsequent read desynced and the header parsed to garbage. Now reads the format for `texb>=3` and the extra int for `texb>=4`, decodes the container for `texb>=3`, and turns the silent `return nullptr` paths into descriptive logs. Verified on workshop item `3471714819`.
- **Addresses #13** — adds **Global Mode**: the wallpaper choice and randomization are shared across all screens via `~/.config/wekde/global.json` instead of per-screen KConfig, so "set for all screens" stays in sync after randomization.

## Performance / memory (multi-monitor)
- **Static pass caching** (`SceneCachePasses`, default on): render graph-static `CustomShaderPass`es (no time/pointer uniforms, all inputs static) are rendered once and skipped afterwards. Saves CPU/GPU. `WP_NO_PASS_CACHE` disables.
- **Shared GPU device** (`ShareGpuContext`, default on): all offscreen renderers on the same GPU share one `VkInstance`/`VkDevice`/VMA/asset cache, so identical textures load once instead of per screen. `WP_SHARE_GPU` overrides.
- **Render-once mirror** (`MirrorScene`, default off / opt-in): when several screens show the same non-mouse-dependent scene at the same resolution/fillmode, only one renders and the others display its frames, reclaiming the per-screen render-target + swapchain. Re-elects a new primary when one leaves. `WP_MIRROR` overrides.

Measured on a real 2×1440p same-wallpaper setup: VRAM 597 → 482 MiB by default (shared device), → 389 MiB with mirror on; mirror also drops the secondary screen's per-frame CPU/GPU to ~zero.

## Stability
- Fix a shutdown SEGV: at plasmashell exit the wallpaper item is leaked, so the render thread kept running `drawFrame`/particle sim against torn-down GL/Vulkan state. The texture node now stops and joins the render loop on teardown.

## Notes
- Mirror is opt-in while it soaks. Known caveat: if the texture node is destroyed and recreated for the same item (transient hide/show), the render loop stays stopped — not hit in normal plasma use (node destruction = shutdown or wallpaper change).