### PR TITLE
fix(scene): prevent crashes after repeated wallpaper changes

### DIFF
--- a/src/backend_scene/src/SceneWallpaper.cpp
+++ b/src/backend_scene/src/SceneWallpaper.cpp
@@ -309,10 +309,15 @@ private:
         }
     }
     MHANDLER_CMD(SET_SCENE) {
-        if (msg->findObject("scene", &m_scene)) {
-            m_scene->cache_passes = main_handler.cachePasses();
+        // Store the incoming scene separately so the outgoing scene remains
+        // alive until queued GPU work completes and its graph is destroyed.
+        std::shared_ptr<Scene> scene;
+        if (msg->findObject("scene", &scene)) {
             m_render->releaseMirror();
             if (m_rg) m_render->clearLastRenderGraph();
+
+            m_scene               = std::move(scene);
+            m_scene->cache_passes = main_handler.cachePasses();
             m_rg = sceneToRenderGraph(*m_scene);
 
             if (main_handler.isGenGraphviz()) m_rg->ToGraphviz("graph.dot");

--- a/src/backend_scene/src/Vulkan/GraphicsPipeline.cpp
+++ b/src/backend_scene/src/Vulkan/GraphicsPipeline.cpp
@@ -154,6 +154,13 @@ GraphicsPipeline& GraphicsPipeline::setTopology(VkPrimitiveTopology topology) {
 
 bool GraphicsPipeline::create(const Device& device, vvk::RenderPass& pass,
                               PipelineParameters& pipeline) {
+    // PipelineParameters is reused across scene changes; release its previous
+    // Vulkan objects and descriptor layouts before rebuilding it.
+    pipeline.handle.reset();
+    pipeline.layout.reset();
+    pipeline.pass.reset();
+    pipeline.descriptor_layouts.clear();
+
     VkPipelineDynamicStateCreateInfo dynamic_info {
         .sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
         .pNext             = nullptr,

--- a/src/backend_scene/src/VulkanRender/VulkanRender.cpp
+++ b/src/backend_scene/src/VulkanRender/VulkanRender.cpp
@@ -646,6 +646,13 @@ void VulkanRender::Impl::releaseMirror() {
 }
 
 void VulkanRender::Impl::clearLastRenderGraph() {
+    // Wait for queued work before destroying resources owned by the old graph.
+    // vkDeviceWaitIdle requires external synchronization with queue submissions.
+    if (m_gpu && device().handle()) {
+        std::lock_guard<std::mutex> lk(device().queue_mutex());
+        VVK_CHECK(device().handle().WaitIdle());
+    }
+
     for (auto& p : m_passes) {
         p->destory(device(), m_rendering_resources);
     }


### PR DESCRIPTION
## Problem

Frequent Wallpaper Engine scene changes could crash `plasmashell`, including
when the same scene selection was replicated across two monitors. The captured
crashes ended in RADV's `vkCreateGraphicsPipelines`; different wallpapers were
active at the time, but each reproduced process failed on its 33rd synchronized
selection.

RainyPixel's persistent `FinPass` reuses `PipelineParameters` across scene
rebuilds. `GraphicsPipeline::create()` appended a descriptor-set layout on each
load without clearing the previous entries. On the tested GPU,
`maxBoundDescriptorSets` is 32, so the 33rd rebuild supplied an invalid
accumulated layout set to Vulkan pipeline creation.

## Fix

- Reset the reused pipeline handle, pipeline layout, render pass, and
  `descriptor_layouts` collection before rebuilding the final pass.
- Keep the outgoing `Scene` alive while the old render graph still references
  its GPU resources.
- Under the existing graphics-queue mutex, wait for the Vulkan device to become
  idle before destroying the old render graph and publishing the replacement
  scene.

The device-idle wait runs during wallpaper replacement, not during normal frame
rendering.

## Validation

- Clean `RelWithDebInfo` build completed from RainyPixel `main` with only these
  three source files changed.
- Existing FileHelper and backend-scene tests passed.
- A focused 45-change synchronized regression run crossed the former 33-change
  boundary without a Plasma restart or new coredump.
- An exhaustive run completed 68 synchronized changes in about 25 minutes
  without a crash. All 48 locally installed projects were activated on both
  monitors at least once: 45 scene, 2 video, and 1 web project. The tester
  stopped the second cycle early, so this is not a completed 35-minute soak.

Test system: KDE Plasma 6.7.4, Qt 6.11.2, Mesa 26.2.1, AMD Radeon RX 9070 XT
using RADV, two monitors.

## Review warning

The diagnosis and patch were produced by OpenAI Codex. The submitter is not a
qualified maintainer, and the change has not received independent review or
broad hardware/driver testing. It is experimental and should receive careful
human review before merge or production use.
